### PR TITLE
Use Clippy in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install clippy
       run: rustup component add clippy
     - name: Run clippy
-      run: cargo clippy
+      run: cargo clippy -- -D warnings
     - name: Update
       run: cargo update
     - name: Check for Wasm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Check format
       run: make dev-format-check
+    - name: Install clippy
+      run: rustup component add clippy
+    - name: Run clippy
+      run: cargo clippy
     - name: Update
       run: cargo update
     - name: Check for Wasm

--- a/auction/src/lib.rs
+++ b/auction/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Disable the following two lints since they originate from an external macro (namely decl_storage)
+#![allow(clippy::string_lit_as_bytes)]
+
 use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure, IterableStorageDoubleMap, Parameter};
 use frame_system::{self as system, ensure_signed};
 use orml_traits::{Auction, AuctionHandler, AuctionInfo};

--- a/auction/src/lib.rs
+++ b/auction/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-
 // Disable the following two lints since they originate from an external macro (namely decl_storage)
 #![allow(clippy::string_lit_as_bytes)]
 

--- a/benchmarking/src/lib.rs
+++ b/benchmarking/src/lib.rs
@@ -133,15 +133,15 @@ pub use sp_runtime::traits::{Dispatchable, One, Zero};
 ///
 /// ```ignore
 /// sort_vector {
-/// 	let x in 1 .. 10000;
-/// 	let mut m = Vec::<u32>::new();
-/// 	for i in (0..x).rev() {
-/// 		m.push(i);
-/// 	}
+///     let x in 1 .. 10000;
+///     let mut m = Vec::<u32>::new();
+///     for i in (0..x).rev() {
+///         m.push(i);
+///     }
 /// }: {
-/// 	m.sort();
+///     m.sort();
 /// } verify {
-/// 	ensure!(m[0] == 0, "You forgot to sort!")
+///     ensure!(m[0] == 0, "You forgot to sort!")
 /// }
 /// ```
 ///

--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -585,24 +585,24 @@ where
 
 	fn set_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) {
 		Currency::set_lock(
-			lock_id.into(),
+			lock_id,
 			who,
 			BalanceConvert::from(amount).into(),
-			(WithdrawReason::Transfer | WithdrawReason::Reserve).into(),
+			WithdrawReason::Transfer | WithdrawReason::Reserve,
 		);
 	}
 
 	fn extend_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) {
 		Currency::extend_lock(
-			lock_id.into(),
+			lock_id,
 			who,
 			BalanceConvert::from(amount).into(),
-			(WithdrawReason::Transfer | WithdrawReason::Reserve).into(),
+			WithdrawReason::Transfer | WithdrawReason::Reserve,
 		);
 	}
 
 	fn remove_lock(lock_id: LockIdentifier, who: &AccountId) {
-		Currency::remove_lock(lock_id.into(), who);
+		Currency::remove_lock(lock_id, who);
 	}
 }
 
@@ -644,7 +644,7 @@ where
 		value: Self::Balance,
 		status: BalanceStatus,
 	) -> result::Result<Self::Balance, DispatchError> {
-		Currency::repatriate_reserved(slashed, beneficiary, BalanceConvert::from(value).into(), status.into())
+		Currency::repatriate_reserved(slashed, beneficiary, BalanceConvert::from(value).into(), status)
 			.map(|a| BalanceConvert::from(a).into())
 	}
 }

--- a/gradually-update/src/lib.rs
+++ b/gradually-update/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Disable the following two lints since they originate from an external macro (namely decl_storage)
+#![allow(clippy::string_lit_as_bytes)]
+
 use codec::{Decode, Encode};
 use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure, storage, traits::Get};
 use frame_system::{self as system, ensure_root};
@@ -116,6 +119,8 @@ impl<T: Trait> Module<T> {
 		}
 
 		let mut gradually_updates = GraduallyUpdates::get();
+
+		#[allow(clippy::redundant_clone)] // FIXME: This looks like a bug in clippy
 		for (i, update) in gradually_updates.clone().iter().enumerate() {
 			let current_value = storage::unhashed::get::<StorageValue>(&update.key).unwrap_or_default();
 			let current_value_u128 = u128::from_le_bytes(Self::convert_vec_to_u8(&current_value));
@@ -127,12 +132,11 @@ impl<T: Trait> Module<T> {
 
 			let target_u128 = u128::from_le_bytes(Self::convert_vec_to_u8(&update.target_value));
 
-			let new_value_u128: u128;
-			if current_value_u128 > target_u128 {
-				new_value_u128 = (current_value_u128.checked_sub(step_u128).unwrap()).max(target_u128);
+			let new_value_u128 = if current_value_u128 > target_u128 {
+				(current_value_u128.checked_sub(step_u128).unwrap()).max(target_u128)
 			} else {
-				new_value_u128 = (current_value_u128.checked_add(step_u128).unwrap()).min(target_u128);
-			}
+				(current_value_u128.checked_add(step_u128).unwrap()).min(target_u128)
+			};
 
 			// current_value equal target_value, remove gradually_update
 			if new_value_u128 == target_u128 {
@@ -155,10 +159,11 @@ impl<T: Trait> Module<T> {
 		GraduallyUpdateBlockNumber::<T>::put(now);
 	}
 
+	#[allow(clippy::ptr_arg)]
 	fn convert_vec_to_u8(input: &StorageValue) -> [u8; 16] {
 		let mut array: [u8; 16] = [0; 16];
 		for (i, v) in input.iter().enumerate() {
-			array[i] = v.clone();
+			array[i] = *v;
 		}
 		array
 	}

--- a/gradually-update/src/lib.rs
+++ b/gradually-update/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-
 // Disable the following two lints since they originate from an external macro (namely decl_storage)
 #![allow(clippy::string_lit_as_bytes)]
 

--- a/oracle/src/default_combine_data.rs
+++ b/oracle/src/default_combine_data.rs
@@ -24,12 +24,7 @@ where
 		let now = T::Time::now();
 		let mut valid_values = values
 			.into_iter()
-			.filter_map(|x| {
-				if x.timestamp + expires_in > now {
-					return Some(x);
-				}
-				None
-			})
+			.filter(|x| x.timestamp + expires_in > now)
 			.collect::<Vec<TimestampedValueOf<T>>>();
 
 		let count = valid_values.len() as u32;
@@ -41,6 +36,6 @@ where
 		valid_values.sort_by(|a, b| a.value.cmp(&b.value));
 
 		let median_index = count / 2;
-		return Some(valid_values[median_index as usize].clone());
+		Some(valid_values[median_index as usize].clone())
 	}
 }

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Disable the following two lints since they originate from an external macro (namely decl_storage)
+#![allow(clippy::string_lit_as_bytes)]
+
 mod default_combine_data;
 mod mock;
 mod operator_provider;
@@ -149,7 +152,7 @@ impl<T: Trait> Module<T> {
 	}
 }
 
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Default)]
 pub struct CheckOperator<T: Trait + Send + Sync>(marker::PhantomData<T>);
 
 impl<T: Trait + Send + Sync> CheckOperator<T> {
@@ -204,7 +207,7 @@ impl<T: Trait + Send + Sync> SignedExtension for CheckOperator<T> {
 				..Default::default()
 			});
 		}
-		return Ok(ValidTransaction::default());
+		Ok(ValidTransaction::default())
 	}
 }
 

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-
 // Disable the following two lints since they originate from an external macro (namely decl_storage)
 #![allow(clippy::string_lit_as_bytes)]
 

--- a/schedule-update/src/lib.rs
+++ b/schedule-update/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Disable the following two lints since they originate from an external macro (namely decl_storage)
+#![allow(clippy::string_lit_as_bytes)]
+
 use codec::{Decode, Encode};
 use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage, ensure,
@@ -160,7 +163,7 @@ decl_module! {
 					origin = frame_system::RawOrigin::Root.into();
 				}
 
-				let result = call.dispatch(origin.clone());
+				let result = call.dispatch(origin);
 				if let Err(e) = result {
 					 Self::deposit_event(RawEvent::ScheduleDispatchFail(id, e.error));
 				} else {
@@ -184,7 +187,7 @@ decl_module! {
 					origin = frame_system::RawOrigin::Root.into();
 				}
 
-				let result = call.dispatch(origin.clone());
+				let result = call.dispatch(origin);
 				if let Err(e) = result {
 					Self::deposit_event(RawEvent::ScheduleDispatchFail(id, e.error));
 				} else {

--- a/schedule-update/src/lib.rs
+++ b/schedule-update/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-
 // Disable the following two lints since they originate from an external macro (namely decl_storage)
 #![allow(clippy::string_lit_as_bytes)]
 

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -32,7 +32,6 @@
 //! The tokens module depends on the `GenesisConfig`. Endowed accounts could be configured in genesis configs.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
 // Disable the following two lints since they originate from an external macro (namely decl_storage)
 #![allow(clippy::redundant_closure_call, clippy::string_lit_as_bytes)]
 
@@ -432,10 +431,7 @@ impl<T: Trait> MultiLockableCurrency<T::AccountId> for Module<T> {
 		if amount.is_zero() {
 			return;
 		}
-		let mut new_lock = Some(BalanceLock {
-			id: lock_id,
-			amount,
-		});
+		let mut new_lock = Some(BalanceLock { id: lock_id, amount });
 		let mut locks = Self::locks(currency_id, who)
 			.into_iter()
 			.filter_map(|lock| {
@@ -458,10 +454,7 @@ impl<T: Trait> MultiLockableCurrency<T::AccountId> for Module<T> {
 		if amount.is_zero() {
 			return;
 		}
-		let mut new_lock = Some(BalanceLock {
-			id: lock_id,
-			amount,
-		});
+		let mut new_lock = Some(BalanceLock { id: lock_id, amount });
 		let mut locks = Self::locks(currency_id, who)
 			.into_iter()
 			.filter_map(|lock| {

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -33,6 +33,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Disable the following two lints since they originate from an external macro (namely decl_storage)
+#![allow(clippy::redundant_closure_call, clippy::string_lit_as_bytes)]
+
 use codec::{Decode, Encode};
 use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure, traits::Get, Parameter};
 use sp_runtime::{
@@ -431,7 +434,7 @@ impl<T: Trait> MultiLockableCurrency<T::AccountId> for Module<T> {
 		}
 		let mut new_lock = Some(BalanceLock {
 			id: lock_id,
-			amount: amount,
+			amount,
 		});
 		let mut locks = Self::locks(currency_id, who)
 			.into_iter()
@@ -457,7 +460,7 @@ impl<T: Trait> MultiLockableCurrency<T::AccountId> for Module<T> {
 		}
 		let mut new_lock = Some(BalanceLock {
 			id: lock_id,
-			amount: amount,
+			amount,
 		});
 		let mut locks = Self::locks(currency_id, who)
 			.into_iter()

--- a/utilities/src/fixed_u128.rs
+++ b/utilities/src/fixed_u128.rs
@@ -274,7 +274,7 @@ impl<'de> Deserialize<'de> for FixedU128 {
 		D: Deserializer<'de>,
 	{
 		let s = String::deserialize(deserializer)?;
-		FixedU128::try_from_u128_str(&s).map_err(|err_str| de::Error::custom(err_str))
+		FixedU128::try_from_u128_str(&s).map_err(de::Error::custom)
 	}
 }
 

--- a/utilities/src/linked_item.rs
+++ b/utilities/src/linked_item.rs
@@ -32,7 +32,7 @@ where
 	}
 
 	fn read(key: &Key, value: Option<Value>) -> LinkedItem<Value> {
-		Storage::get(&(key.clone(), value)).unwrap_or_else(|| Default::default())
+		Storage::get(&(key.clone(), value)).unwrap_or_else(Default::default)
 	}
 
 	fn take(key: &Key, value: Value) -> LinkedItem<Value> {

--- a/vesting/src/lib.rs
+++ b/vesting/src/lib.rs
@@ -21,7 +21,6 @@
 //! - `update_vesting_schedules` - Update all vesting schedules under an account, `root` origin required.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
 // Disable the following two lints since they originate from an external macro (namely decl_storage)
 #![allow(clippy::redundant_closure_call, clippy::string_lit_as_bytes)]
 


### PR DESCRIPTION
Fixes #19.

We may also want to configure clippy so that it errors on every warning in CI.