### PR TITLE
add OnReceived to tokens Trait

### DIFF
--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -88,6 +88,7 @@ impl tokens::Trait for Runtime {
 	type Amount = i64;
 	type CurrencyId = CurrencyId;
 	type DustRemoval = ();
+	type OnReceived = ();
 }
 pub type Tokens = tokens::Module<Runtime>;
 

--- a/currencies/src/tests.rs
+++ b/currencies/src/tests.rs
@@ -17,7 +17,7 @@ fn multi_lockable_currency_should_work() {
 		.build()
 		.execute_with(|| {
 			Currencies::set_lock(ID_1, X_TOKEN_ID, &ALICE, 50);
-			assert_eq!(Tokens::locks(X_TOKEN_ID, &ALICE).len(), 1);
+			assert_eq!(Tokens::locks(&ALICE, X_TOKEN_ID).len(), 1);
 			Currencies::set_lock(ID_1, NATIVE_CURRENCY_ID, &ALICE, 50);
 			assert_eq!(PalletBalances::locks(&ALICE).len(), 1);
 		});

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -92,12 +92,33 @@ impl OnDustRemoval<CurrencyId, Balance> for MockDustRemoval<CurrencyId, Balance>
 	}
 }
 
+thread_local! {
+	pub static ACCUMULATED_RECEIVED: RefCell<HashMap<(AccountId, CurrencyId), Balance>> = RefCell::new(HashMap::new());
+}
+
+pub struct MockOnReceived;
+impl OnReceived<AccountId, CurrencyId, Balance> for MockOnReceived {
+	fn on_received(who: AccountId, currency_id: CurrencyId, amount: Balance) {
+		ACCUMULATED_RECEIVED.with(|v| {
+			let mut old_map = v.borrow().clone();
+			if let Some(before) = old_map.get_mut(&(who, currency_id)) {
+				*before += amount;
+			} else {
+				old_map.insert((who, currency_id), amount);
+			};
+
+			*v.borrow_mut() = old_map;
+		});
+	}
+}
+
 impl Trait for Runtime {
 	type Event = TestEvent;
 	type Balance = Balance;
 	type Amount = i64;
 	type CurrencyId = CurrencyId;
 	type DustRemoval = MockDustRemoval<CurrencyId, Balance>;
+	type OnReceived = MockOnReceived;
 }
 
 pub type Tokens = Module<Runtime>;

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -16,15 +16,15 @@ fn set_lock_should_work() {
 		.build()
 		.execute_with(|| {
 			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 10);
-			assert_eq!(Tokens::accounts(TEST_TOKEN_ID, &ALICE).frozen, 10);
-			assert_eq!(Tokens::accounts(TEST_TOKEN_ID, &ALICE).frozen(), 10);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 1);
+			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 10);
+			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen(), 10);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
 			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 50);
-			assert_eq!(Tokens::accounts(TEST_TOKEN_ID, &ALICE).frozen, 50);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 1);
+			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 50);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
 			Tokens::set_lock(ID_2, TEST_TOKEN_ID, &ALICE, 60);
-			assert_eq!(Tokens::accounts(TEST_TOKEN_ID, &ALICE).frozen, 60);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 2);
+			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 60);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 2);
 		});
 }
 
@@ -35,14 +35,14 @@ fn extend_lock_should_work() {
 		.build()
 		.execute_with(|| {
 			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 10);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 1);
-			assert_eq!(Tokens::accounts(TEST_TOKEN_ID, &ALICE).frozen, 10);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
+			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 10);
 			Tokens::extend_lock(ID_1, TEST_TOKEN_ID, &ALICE, 20);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 1);
-			assert_eq!(Tokens::accounts(TEST_TOKEN_ID, &ALICE).frozen, 20);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
+			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 20);
 			Tokens::extend_lock(ID_2, TEST_TOKEN_ID, &ALICE, 10);
 			Tokens::extend_lock(ID_1, TEST_TOKEN_ID, &ALICE, 20);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 2);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 2);
 		});
 }
 
@@ -54,9 +54,9 @@ fn remove_lock_should_work() {
 		.execute_with(|| {
 			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 10);
 			Tokens::set_lock(ID_2, TEST_TOKEN_ID, &ALICE, 20);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 2);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 2);
 			Tokens::remove_lock(ID_2, TEST_TOKEN_ID, &ALICE);
-			assert_eq!(Tokens::locks(TEST_TOKEN_ID, ALICE).len(), 1);
+			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
 		});
 }
 

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -4,7 +4,10 @@
 
 use super::*;
 use frame_support::{assert_noop, assert_ok};
-use mock::{Balance, ExtBuilder, Runtime, System, TestEvent, Tokens, ALICE, BOB, ID_1, ID_2, TEST_TOKEN_ID};
+use mock::{
+	Balance, ExtBuilder, Runtime, System, TestEvent, Tokens, ACCUMULATED_RECEIVED, ALICE, BOB, ID_1, ID_2,
+	TEST_TOKEN_ID,
+};
 
 #[test]
 fn set_lock_should_work() {
@@ -247,6 +250,10 @@ fn transfer_should_work() {
 			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
 			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 150);
 			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
+			assert_eq!(
+				ACCUMULATED_RECEIVED.with(|v| *v.borrow().get(&(BOB, TEST_TOKEN_ID)).unwrap()),
+				50
+			);
 
 			let transferred_event = TestEvent::tokens(RawEvent::Transferred(TEST_TOKEN_ID, ALICE, BOB, 50));
 			assert!(System::events().iter().any(|record| record.event == transferred_event));

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -334,3 +334,11 @@ impl<CurrencyId, Balance> OnDustRemoval<CurrencyId, Balance> for () {
 pub trait OnRedundantCall<AccountId> {
 	fn multiple_calls_per_block(who: &AccountId);
 }
+
+pub trait OnReceived<AccountId, CurrencyId, Balance> {
+	fn on_received(account: AccountId, currency: CurrencyId, amount: Balance);
+}
+
+impl<AccountId, CurrencyId, Balance> OnReceived<AccountId, CurrencyId, Balance> for () {
+	fn on_received(_: AccountId, _: CurrencyId, _: Balance) {}
+}


### PR DESCRIPTION
1. add `OnReceived` to `orml-tokens` Trait according to https://github.com/AcalaNetwork/Acala/issues/236

2. Update the map key of storage `Accounts` and `Locks` in `orml-tokens` :  
        `CurrencyId, AccountId` =>  `AccountId, CurrencyId`  , in order to iterate all currencies of a specific account. Note: This change will break front end, SDK and bot which query `Accounts` and `Locks` storage. @qwer951123 @RomeroYang @shaopengw 