### PR TITLE
Minor fixes for clippy

### DIFF
--- a/auction/src/mock.rs
+++ b/auction/src/mock.rs
@@ -76,7 +76,7 @@ impl AuctionHandler<AccountId, Balance, BlockNumber, AuctionId> for Handler {
 	) -> OnNewBidResult<BlockNumber> {
 		OnNewBidResult {
 			accept_bid: true,
-			auction_end: None,
+			auction_end_change: AuctionEndChange::NoChange,
 		}
 	}
 

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -32,8 +32,6 @@
 //! The tokens module depends on the `GenesisConfig`. Endowed accounts could be configured in genesis configs.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// Disable the following two lints since they originate from an external macro (namely decl_storage)
-#![allow(clippy::redundant_closure_call, clippy::string_lit_as_bytes)]
 
 use codec::{Decode, Encode};
 use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure, traits::Get, Parameter};

--- a/traits/src/auction.rs
+++ b/traits/src/auction.rs
@@ -38,12 +38,19 @@ pub trait Auction<AccountId, BlockNumber> {
 	fn remove_auction(id: Self::AuctionId);
 }
 
+pub enum AuctionEndChange<BlockNumber> {
+	/// No change.
+	NoChange,
+	/// Changed to a new end.
+	Changed(Option<BlockNumber>),
+}
+
 /// The result of bid handling.
 pub struct OnNewBidResult<BlockNumber> {
 	/// Indicates if the bid was accepted
 	pub accept_bid: bool,
-	/// `None` means don't change, `Some(None)` means no more auction end time, `Some(Some(number))` means set auction end time to this block
-	pub auction_end: Option<Option<BlockNumber>>,
+	/// The auction deadline change.
+	pub auction_end_change: AuctionEndChange<BlockNumber>,
 }
 
 /// Hooks for auction to handle bids.

--- a/traits/src/auction.rs
+++ b/traits/src/auction.rs
@@ -49,7 +49,7 @@ pub enum AuctionEndChange<BlockNumber> {
 pub struct OnNewBidResult<BlockNumber> {
 	/// Indicates if the bid was accepted
 	pub accept_bid: bool,
-	/// The auction deadline change.
+	/// The auction end change.
 	pub auction_end_change: AuctionEndChange<BlockNumber>,
 }
 

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod arithmetic;
 pub mod auction;
 
-pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
+pub use auction::{Auction, AuctionEndChange, AuctionHandler, AuctionInfo, OnNewBidResult};
 use codec::{Codec, FullCodec};
 pub use frame_support::traits::{BalanceStatus, LockIdentifier};
 use sp_runtime::{

--- a/vesting/src/lib.rs
+++ b/vesting/src/lib.rs
@@ -21,8 +21,6 @@
 //! - `update_vesting_schedules` - Update all vesting schedules under an account, `root` origin required.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// Disable the following two lints since they originate from an external macro (namely decl_storage)
-#![allow(clippy::redundant_closure_call, clippy::string_lit_as_bytes)]
 
 use codec::{Decode, Encode, HasCompact};
 use frame_support::{


### PR DESCRIPTION
- Remove non-necessary clippy workarounds with `decl_module` change.
- Refactor `OnNewBidResult` for clippy warning.

Closes #170 