### PR TITLE
Comparable and debug printable AuctionEndChange.

### DIFF
--- a/traits/src/auction.rs
+++ b/traits/src/auction.rs
@@ -38,6 +38,7 @@ pub trait Auction<AccountId, BlockNumber> {
 	fn remove_auction(id: Self::AuctionId);
 }
 
+#[derive(Eq, PartialEq, RuntimeDebug)]
 pub enum AuctionEndChange<BlockNumber> {
 	/// No change.
 	NoChange,


### PR DESCRIPTION
The unit tests in acala auction manager need `AuctionEndChange` to be comparable and debug printable.