### PR TITLE
update AccountId type in mocks to u128

### DIFF
--- a/auction/src/mock.rs
+++ b/auction/src/mock.rs
@@ -34,7 +34,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-pub type AccountId = u64;
+pub type AccountId = u128;
 pub type Balance = u64;
 pub type BlockNumber = u64;
 pub type AuctionId = u64;
@@ -86,7 +86,7 @@ impl AuctionHandler<AccountId, Balance, BlockNumber, AuctionId> for Handler {
 impl Trait for Runtime {
 	type Event = TestEvent;
 	type Balance = Balance;
-	type AuctionId = AccountId;
+	type AuctionId = AuctionId;
 	type Handler = Handler;
 }
 pub type AuctionModule = Module<Runtime>;

--- a/benchmarking/src/tests.rs
+++ b/benchmarking/src/tests.rs
@@ -49,7 +49,7 @@ pub trait Trait {
 	type Origin: From<frame_system::RawOrigin<Self::AccountId>> + Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>;
 }
 
-type AccountId = u64;
+type AccountId = u128;
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
@@ -84,7 +84,7 @@ impl Trait for Test {
 	type Event = ();
 	type BlockNumber = u32;
 	type Origin = Origin;
-	type AccountId = u64;
+	type AccountId = u128;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -38,7 +38,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-pub type AccountId = u64;
+pub type AccountId = u128;
 impl frame_system::Trait for Runtime {
 	type Origin = Origin;
 	type Call = ();

--- a/gradually-update/src/mock.rs
+++ b/gradually-update/src/mock.rs
@@ -34,7 +34,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-pub type AccountId = u64;
+pub type AccountId = u128;
 pub type BlockNumber = u64;
 
 impl frame_system::Trait for Runtime {

--- a/oracle/src/mock.rs
+++ b/oracle/src/mock.rs
@@ -22,7 +22,7 @@ impl_outer_dispatch! {
 }
 
 pub type OracleCall = super::Call<Test>;
-type AccountId = u64;
+pub type AccountId = u128;
 type Key = u32;
 type Value = u32;
 

--- a/oracle/src/tests.rs
+++ b/oracle/src/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{
-	mock::{new_test_ext, ModuleOracle, OracleCall, Origin, Timestamp},
+	mock::{new_test_ext, AccountId, ModuleOracle, OracleCall, Origin, Timestamp},
 	TimestampedValue,
 };
 use codec::Encode;
@@ -33,7 +33,7 @@ fn feed_values_from_session_key(
 }
 
 fn feed_values(
-	from: u64,
+	from: AccountId,
 	index: u32,
 	nonce: u32,
 	values: Vec<(u32, u32)>,
@@ -46,7 +46,7 @@ fn feed_values(
 #[test]
 fn should_feed_values() {
 	new_test_ext().execute_with(|| {
-		let account_id: u64 = 1;
+		let account_id: AccountId = 1;
 
 		assert_ok!(feed_values(account_id, 0, 0, vec![(50, 1000), (51, 900), (52, 800)]));
 
@@ -274,7 +274,7 @@ fn bad_index() {
 #[test]
 fn change_member_should_work() {
 	new_test_ext().execute_with(|| {
-		<ModuleOracle as ChangeMembers<u64>>::change_members_sorted(&[4], &[1], &[2, 3, 4]);
+		<ModuleOracle as ChangeMembers<AccountId>>::change_members_sorted(&[4], &[1], &[2, 3, 4]);
 
 		assert_noop!(
 			feed_values_from_session_key(10.into(), 0, 0, vec![(50, 1000)]),

--- a/schedule-update/src/mock.rs
+++ b/schedule-update/src/mock.rs
@@ -41,7 +41,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-pub type AccountId = u64;
+pub type AccountId = u128;
 pub type BlockNumber = u64;
 
 impl frame_system::Trait for Runtime {
@@ -83,8 +83,8 @@ impl pallet_balances::Trait for Runtime {
 	type AccountStore = System;
 }
 
-pub const ALICE: AccountId = 1u64;
-pub const BOB: AccountId = 2u64;
+pub const ALICE: AccountId = 1;
+pub const BOB: AccountId = 2;
 
 // A mock schedule origin where only `ALICE` has permission.
 pub struct MockScheduleOrigin;

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -36,7 +36,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-type AccountId = u64;
+type AccountId = u128;
 impl frame_system::Trait for Runtime {
 	type Origin = Origin;
 	type Call = ();

--- a/utilities/src/linked_item.rs
+++ b/utilities/src/linked_item.rs
@@ -203,7 +203,7 @@ mod tests {
 		type Call = ();
 		type Hash = H256;
 		type Hashing = ::sp_runtime::traits::BlakeTwo256;
-		type AccountId = u64;
+		type AccountId = u128;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
 		type Event = ();

--- a/vesting/src/mock.rs
+++ b/vesting/src/mock.rs
@@ -34,7 +34,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-pub type AccountId = u64;
+pub type AccountId = u128;
 impl frame_system::Trait for Runtime {
 	type Origin = Origin;
 	type Call = ();


### PR DESCRIPTION
Found few issues when using u64 because identical accounts could be generated from different ModuleId. Best to never use `AccountId = u64` for all tests.