### PR TITLE
make Change reusable

### DIFF
--- a/auction/src/lib.rs
+++ b/auction/src/lib.rs
@@ -6,7 +6,7 @@ use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage, ensure, traits::Get, IterableStorageDoubleMap, Parameter,
 };
 use frame_system::{self as system, ensure_signed};
-use orml_traits::{Auction, AuctionEndChange, AuctionHandler, AuctionInfo};
+use orml_traits::{Auction, AuctionHandler, AuctionInfo, Change};
 use sp_runtime::{
 	traits::{AtLeast32Bit, MaybeSerializeDeserialize, Member, One, Zero},
 	DispatchResult,
@@ -90,7 +90,7 @@ decl_module! {
 
 			ensure!(bid_result.accept_bid, Error::<T>::BidNotAccepted);
 			match bid_result.auction_end_change {
-				AuctionEndChange::Changed(new_end) => {
+				Change::Changed(new_end) => {
 					if let Some(old_end_block) = auction.end {
 						<AuctionEndTime<T>>::remove(&old_end_block, id);
 					}
@@ -99,7 +99,7 @@ decl_module! {
 					}
 					auction.end = new_end;
 				},
-				AuctionEndChange::NoChange => {},
+				Change::NoChange => {},
 			}
 			auction.bid = Some((from.clone(), value));
 			<Auctions<T>>::insert(id, auction);

--- a/auction/src/lib.rs
+++ b/auction/src/lib.rs
@@ -90,7 +90,7 @@ decl_module! {
 
 			ensure!(bid_result.accept_bid, Error::<T>::BidNotAccepted);
 			match bid_result.auction_end_change {
-				Change::Changed(new_end) => {
+				Change::NewValue(new_end) => {
 					if let Some(old_end_block) = auction.end {
 						<AuctionEndTime<T>>::remove(&old_end_block, id);
 					}

--- a/auction/src/mock.rs
+++ b/auction/src/mock.rs
@@ -76,7 +76,7 @@ impl AuctionHandler<AccountId, Balance, BlockNumber, AuctionId> for Handler {
 	) -> OnNewBidResult<BlockNumber> {
 		OnNewBidResult {
 			accept_bid: true,
-			auction_end_change: AuctionEndChange::NoChange,
+			auction_end_change: Change::NoChange,
 		}
 	}
 

--- a/traits/src/auction.rs
+++ b/traits/src/auction.rs
@@ -1,3 +1,4 @@
+use crate::Change;
 use codec::FullCodec;
 use codec::{Decode, Encode};
 use sp_runtime::{
@@ -38,20 +39,12 @@ pub trait Auction<AccountId, BlockNumber> {
 	fn remove_auction(id: Self::AuctionId);
 }
 
-#[derive(Eq, PartialEq, RuntimeDebug)]
-pub enum AuctionEndChange<BlockNumber> {
-	/// No change.
-	NoChange,
-	/// Changed to a new end.
-	Changed(Option<BlockNumber>),
-}
-
 /// The result of bid handling.
 pub struct OnNewBidResult<BlockNumber> {
 	/// Indicates if the bid was accepted
 	pub accept_bid: bool,
 	/// The auction end change.
-	pub auction_end_change: AuctionEndChange<BlockNumber>,
+	pub auction_end_change: Change<Option<BlockNumber>>,
 }
 
 /// Hooks for auction to handle bids.

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -7,7 +7,7 @@ use sp_std::{
 	prelude::Vec,
 };
 
-pub use auction::{Auction, AuctionEndChange, AuctionHandler, AuctionInfo, OnNewBidResult};
+pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
 pub use currency::{
 	BalanceStatus, BasicCurrency, BasicCurrencyExtended, BasicLockableCurrency, BasicReservableCurrency,
 	LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency,
@@ -64,4 +64,12 @@ pub trait Scheduler<BlockNumber> {
 
 	fn schedule(origin: Self::Origin, call: Self::Call, when: DelayedDispatchTime<BlockNumber>) -> DispatchId;
 	fn cancel(id: DispatchId);
+}
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
+pub enum Change<Value> {
+	/// No change.
+	NoChange,
+	/// Changed to new value.
+	Changed(Value),
 }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -71,5 +71,5 @@ pub enum Change<Value> {
 	/// No change.
 	NoChange,
 	/// Changed to new value.
-	Changed(Value),
+	NewValue(Value),
 }


### PR DESCRIPTION
this can also replace `CollateralParamChange` in Acala