### PR TITLE
remove redundant dep

### DIFF
--- a/benchmarking/Cargo.toml
+++ b/benchmarking/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-linregress = "0.3.0"
 paste = "0.1.16"
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-api = { version = "2.0.0-rc2", default-features = false }


### PR DESCRIPTION
remove redundant dep which will cause duplicate lang item in crate error when introduce `frame-benchmarking` at the same time