### PR TITLE
allow unnecessary_mut_passed warning

### DIFF
--- a/oracle/rpc/runtime-api/src/lib.rs
+++ b/oracle/rpc/runtime-api/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // The `too_many_arguments` warning originates from `decl_runtime_apis` macro.
 #![allow(clippy::too_many_arguments)]
+// The `unnecessary_mut_passed` warning originates from `decl_runtime_apis` macro.
 #![allow(clippy::unnecessary_mut_passed)]
 
 use codec::Codec;

--- a/oracle/rpc/runtime-api/src/lib.rs
+++ b/oracle/rpc/runtime-api/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // The `too_many_arguments` warning originates from `decl_runtime_apis` macro.
 #![allow(clippy::too_many_arguments)]
+#![allow(clippy::unnecessary_mut_passed)]
 
 use codec::Codec;
 use sp_std::prelude::Vec;


### PR DESCRIPTION
The `unnecessary_mut_passed` warning originates from `decl_runtime_apis` macro.