### PR TITLE
fix orml-vesting

### DIFF
--- a/traits/src/currency.rs
+++ b/traits/src/currency.rs
@@ -289,12 +289,9 @@ pub trait BasicReservableCurrency<AccountId>: BasicCurrency<AccountId> {
 	) -> result::Result<Self::Balance, DispatchError>;
 }
 
+#[impl_trait_for_tuples::impl_for_tuples(30)]
 pub trait OnDustRemoval<CurrencyId, Balance> {
 	fn on_dust_removal(currency_id: CurrencyId, balance: Balance);
-}
-
-impl<CurrencyId, Balance> OnDustRemoval<CurrencyId, Balance> for () {
-	fn on_dust_removal(_: CurrencyId, _: Balance) {}
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(30)]

--- a/vesting/src/mock.rs
+++ b/vesting/src/mock.rs
@@ -67,6 +67,7 @@ type Balance = u64;
 
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
+	pub const MinVestedTransfer: u64 = 5;
 }
 
 impl pallet_balances::Trait for Runtime {
@@ -81,6 +82,7 @@ pub type PalletBalances = pallet_balances::Module<Runtime>;
 impl Trait for Runtime {
 	type Event = TestEvent;
 	type Currency = PalletBalances;
+	type MinVestedTransfer = MinVestedTransfer;
 }
 pub type Vesting = Module<Runtime>;
 

--- a/vesting/src/tests.rs
+++ b/vesting/src/tests.rs
@@ -8,7 +8,7 @@ use mock::{ExtBuilder, Origin, PalletBalances, Runtime, System, TestEvent, Vesti
 use pallet_balances::{BalanceLock, Reasons};
 
 #[test]
-fn add_vesting_schedule_works() {
+fn vested_transfer_works() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
 		System::set_block_number(1);
 
@@ -18,11 +18,7 @@ fn add_vesting_schedule_works() {
 			period_count: 1u32,
 			per_period: 100u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(
-			Origin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
+		assert_ok!(Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule.clone()));
 		assert_eq!(Vesting::vesting_schedules(&BOB), vec![schedule.clone()]);
 
 		let vested_event = TestEvent::vesting(RawEvent::VestingScheduleAdded(ALICE, BOB, schedule));
@@ -39,7 +35,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			period_count: 2u32,
 			per_period: 10u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule));
+		assert_ok!(Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule));
 
 		System::set_block_number(12);
 
@@ -49,11 +45,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			period_count: 1u32,
 			per_period: 7u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(
-			Origin::signed(ALICE),
-			BOB,
-			another_schedule
-		));
+		assert_ok!(Vesting::vested_transfer(Origin::signed(ALICE), BOB, another_schedule));
 
 		assert_eq!(
 			PalletBalances::locks(&BOB).pop(),
@@ -75,17 +67,13 @@ fn cannot_use_fund_if_not_claimed() {
 			period_count: 1u32,
 			per_period: 50u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(
-			Origin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
+		assert_ok!(Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule.clone()));
 		assert!(PalletBalances::ensure_can_withdraw(&BOB, 1, WithdrawReason::Transfer.into(), 49).is_err());
 	});
 }
 
 #[test]
-fn add_vesting_schedule_fails_if_zero_period_or_count() {
+fn vested_transfer_fails_if_zero_period_or_count() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
 		let schedule = VestingSchedule {
 			start: 1u64,
@@ -94,7 +82,7 @@ fn add_vesting_schedule_fails_if_zero_period_or_count() {
 			per_period: 100u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule.clone()),
+			Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule.clone()),
 			Error::<Runtime>::ZeroVestingPeriod
 		);
 
@@ -105,14 +93,14 @@ fn add_vesting_schedule_fails_if_zero_period_or_count() {
 			per_period: 100u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule.clone()),
+			Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule.clone()),
 			Error::<Runtime>::ZeroVestingPeriodCount
 		);
 	});
 }
 
 #[test]
-fn add_vesting_schedule_fails_if_transfer_err() {
+fn vested_transfer_fails_if_transfer_err() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
 		let schedule = VestingSchedule {
 			start: 1u64,
@@ -121,14 +109,14 @@ fn add_vesting_schedule_fails_if_transfer_err() {
 			per_period: 100u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(BOB), ALICE, schedule.clone()),
+			Vesting::vested_transfer(Origin::signed(BOB), ALICE, schedule.clone()),
 			pallet_balances::Error::<Runtime, _>::InsufficientBalance,
 		);
 	});
 }
 
 #[test]
-fn add_vesting_schedule_fails_if_overflow() {
+fn vested_transfer_fails_if_overflow() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
 		let schedule = VestingSchedule {
 			start: 1u64,
@@ -137,7 +125,7 @@ fn add_vesting_schedule_fails_if_overflow() {
 			per_period: u64::max_value(),
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule),
+			Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule),
 			Error::<Runtime>::NumOverflow
 		);
 
@@ -148,7 +136,7 @@ fn add_vesting_schedule_fails_if_overflow() {
 			per_period: 1u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, another_schedule),
+			Vesting::vested_transfer(Origin::signed(ALICE), BOB, another_schedule),
 			Error::<Runtime>::NumOverflow
 		);
 	});
@@ -163,11 +151,7 @@ fn claim_works() {
 			period_count: 2u32,
 			per_period: 10u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(
-			Origin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
+		assert_ok!(Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule.clone()));
 
 		System::set_block_number(11);
 		// remain locked if not claimed
@@ -199,11 +183,7 @@ fn update_vesting_schedules_works() {
 			period_count: 2u32,
 			per_period: 10u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(
-			Origin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
+		assert_ok!(Vesting::vested_transfer(Origin::signed(ALICE), BOB, schedule.clone()));
 
 		let updated_schedule = VestingSchedule {
 			start: 0u64,
@@ -234,3 +214,7 @@ fn update_vesting_schedules_fails_if_unexpected_existing_locks() {
 		PalletBalances::set_lock(*b"prelocks", &BOB, 0u64, WithdrawReasons::all());
 	});
 }
+
+// TODO: check for MinVestedTransfer
+// check expired vesting schedules get removed
+// check storage get cleared when no more schedule left


### PR DESCRIPTION
Rename `add_vesting_schedule` to `vested_transfer` to match pallet-vesting
Add `MAX_VESTINGS` to limit vec length
Remove expired schedules
Require `MinVestedTransfer`