### PR TITLE
Gradually update renaming and typo fixing.

### DIFF
--- a/gradually-update/src/tests.rs
+++ b/gradually-update/src/tests.rs
@@ -27,7 +27,7 @@ fn gradually_update_should_work() {
 		};
 		assert_ok!(GraduallyUpdateModule::gradually_update(Origin::root(), update.clone()));
 
-		let gradually_update_event = TestEvent::gradually_update(RawEvent::GraduallyUpdate(
+		let gradually_update_event = TestEvent::gradually_update(RawEvent::GraduallyUpdateAdded(
 			update.key,
 			update.per_block,
 			update.target_value,
@@ -88,7 +88,7 @@ fn cancel_gradually_update_should_work() {
 			per_block: vec![1],
 		};
 		assert_ok!(GraduallyUpdateModule::gradually_update(Origin::root(), update.clone()));
-		let gradually_update_event = TestEvent::gradually_update(RawEvent::GraduallyUpdate(
+		let gradually_update_event = TestEvent::gradually_update(RawEvent::GraduallyUpdateAdded(
 			update.key.clone(),
 			update.per_block,
 			update.target_value,
@@ -101,7 +101,7 @@ fn cancel_gradually_update_should_work() {
 			Origin::root(),
 			update.key.clone()
 		));
-		let cancel_gradually_update_event = TestEvent::gradually_update(RawEvent::CancelGraduallyUpdate(update.key));
+		let cancel_gradually_update_event = TestEvent::gradually_update(RawEvent::GraduallyUpdateCancelled(update.key));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == cancel_gradually_update_event));
@@ -118,7 +118,7 @@ fn cancel_gradually_update_should_fail() {
 		};
 		assert_noop!(
 			GraduallyUpdateModule::cancel_gradually_update(Origin::root(), update.key.clone()),
-			Error::<Runtime>::CancelGradullyUpdateNotExisted
+			Error::<Runtime>::GraduallyUpdateNotFound
 		);
 
 		assert_ok!(GraduallyUpdateModule::gradually_update(Origin::root(), update.clone()));
@@ -146,7 +146,7 @@ fn add_on_finalize_should_work() {
 		GraduallyUpdateModule::on_finalize(10);
 		assert_eq!(storage_get(&update.key), vec![10]);
 		let gradually_update_blocknumber_event =
-			TestEvent::gradually_update(RawEvent::GraduallyUpdateBlockNumber(10, update.key.clone(), vec![10]));
+			TestEvent::gradually_update(RawEvent::Updated(10, update.key.clone(), vec![10]));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == gradually_update_blocknumber_event));
@@ -159,7 +159,7 @@ fn add_on_finalize_should_work() {
 		GraduallyUpdateModule::on_finalize(20);
 		assert_eq!(storage_get(&update.key), vec![20]);
 		let gradually_update_blocknumber_event =
-			TestEvent::gradually_update(RawEvent::GraduallyUpdateBlockNumber(20, update.key.clone(), vec![20]));
+			TestEvent::gradually_update(RawEvent::Updated(20, update.key.clone(), vec![20]));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == gradually_update_blocknumber_event));
@@ -168,7 +168,7 @@ fn add_on_finalize_should_work() {
 		GraduallyUpdateModule::on_finalize(40);
 		assert_eq!(storage_get(&update.key), vec![30]);
 		let gradually_update_blocknumber_event =
-			TestEvent::gradually_update(RawEvent::GraduallyUpdateBlockNumber(40, update.key.clone(), vec![30]));
+			TestEvent::gradually_update(RawEvent::Updated(40, update.key.clone(), vec![30]));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == gradually_update_blocknumber_event));
@@ -193,7 +193,7 @@ fn sub_on_finalize_should_work() {
 		GraduallyUpdateModule::on_finalize(10);
 		assert_eq!(storage_get(&update.key), vec![20]);
 		let gradually_update_blocknumber_event =
-			TestEvent::gradually_update(RawEvent::GraduallyUpdateBlockNumber(10, update.key.clone(), vec![20]));
+			TestEvent::gradually_update(RawEvent::Updated(10, update.key.clone(), vec![20]));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == gradually_update_blocknumber_event));
@@ -206,7 +206,7 @@ fn sub_on_finalize_should_work() {
 		GraduallyUpdateModule::on_finalize(20);
 		assert_eq!(storage_get(&update.key), vec![10]);
 		let gradually_update_blocknumber_event =
-			TestEvent::gradually_update(RawEvent::GraduallyUpdateBlockNumber(20, update.key.clone(), vec![10]));
+			TestEvent::gradually_update(RawEvent::Updated(20, update.key.clone(), vec![10]));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == gradually_update_blocknumber_event));
@@ -215,7 +215,7 @@ fn sub_on_finalize_should_work() {
 		GraduallyUpdateModule::on_finalize(40);
 		assert_eq!(storage_get(&update.key), vec![5]);
 		let gradually_update_blocknumber_event =
-			TestEvent::gradually_update(RawEvent::GraduallyUpdateBlockNumber(40, update.key.clone(), vec![5]));
+			TestEvent::gradually_update(RawEvent::Updated(40, update.key.clone(), vec![5]));
 		assert!(System::events()
 			.iter()
 			.any(|record| record.event == gradually_update_blocknumber_event));


### PR DESCRIPTION
- Updated errors and events naming to comply the conventions.
- Fix typos.