### PR TITLE
avoid nightly features

### DIFF
--- a/traits/src/data_provider.rs
+++ b/traits/src/data_provider.rs
@@ -29,9 +29,11 @@ pub fn median<T: Ord + Clone>(mut items: Vec<T>) -> Option<T> {
 	}
 
 	let mid_index = items.len() / 2;
+
+	items.sort();
+
 	// Won't panic as guarded items not empty case.
-	let (_, median, _) = items.partition_at_index(mid_index);
-	Some(median.clone())
+	Some(items[mid_index as usize].clone())
 }
 
 #[macro_export]

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(slice_partition_at_index)]
 
 use codec::{Decode, Encode};
 use sp_runtime::RuntimeDebug;


### PR DESCRIPTION
So ORML can be build with stable rust.

cc @AtenJin 