### PR TITLE
refactor tokens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2020-09-27
+        toolchain: nightly-2020-11-16
         components: rustfmt
         target: wasm32-unknown-unknown
         override: true

--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -234,6 +234,14 @@ impl<T: Trait> MultiCurrency<T::AccountId> for Module<T> {
 	type CurrencyId = CurrencyIdOf<T>;
 	type Balance = BalanceOf<T>;
 
+	fn minimum_balance(currency_id: Self::CurrencyId) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::minimum_balance()
+		} else {
+			T::MultiCurrency::minimum_balance(currency_id)
+		}
+	}
+
 	fn total_issuance(currency_id: Self::CurrencyId) -> Self::Balance {
 		if currency_id == T::GetNativeCurrencyId::get() {
 			T::NativeCurrency::total_issuance()
@@ -434,6 +442,10 @@ where
 {
 	type Balance = BalanceOf<T>;
 
+	fn minimum_balance() -> Self::Balance {
+		<Module<T>>::minimum_balance(GetCurrencyId::get())
+	}
+
 	fn total_issuance() -> Self::Balance {
 		<Module<T>>::total_issuance(GetCurrencyId::get())
 	}
@@ -559,6 +571,10 @@ where
 	T: Trait,
 {
 	type Balance = PalletBalanceOf<AccountId, Currency>;
+
+	fn minimum_balance() -> Self::Balance {
+		Currency::minimum_balance()
+	}
 
 	fn total_issuance() -> Self::Balance {
 		Currency::total_issuance()

--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -5,7 +5,7 @@
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use pallet_balances;
 use sp_core::H256;
-use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
+use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32, Perbill};
 
 use tokens;
 
@@ -38,7 +38,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-pub type AccountId = u128;
+pub type AccountId = AccountId32;
 impl frame_system::Trait for Runtime {
 	type Origin = Origin;
 	type Call = ();
@@ -87,6 +87,10 @@ impl pallet_balances::Trait for Runtime {
 
 pub type PalletBalances = pallet_balances::Module<Runtime>;
 
+parameter_types! {
+	pub ExistenceDeposits: Vec<(CurrencyId, Balance)> = vec![];
+}
+
 impl tokens::Trait for Runtime {
 	type Event = TestEvent;
 	type Balance = Balance;
@@ -94,6 +98,9 @@ impl tokens::Trait for Runtime {
 	type CurrencyId = CurrencyId;
 	type OnReceived = ();
 	type WeightInfo = ();
+	type ExistenceDeposits = ExistenceDeposits;
+	type OnDust = ();
+	type AccountIdConvert = AccountId;
 }
 pub type Tokens = tokens::Module<Runtime>;
 
@@ -115,9 +122,9 @@ pub type Currencies = Module<Runtime>;
 pub type NativeCurrency = NativeCurrencyOf<Runtime>;
 pub type AdaptedBasicCurrency = BasicCurrencyAdapter<Runtime, PalletBalances, i64, u64>;
 
-pub const ALICE: AccountId = 1;
-pub const BOB: AccountId = 2;
-pub const EVA: AccountId = 5;
+pub const ALICE: AccountId = AccountId32::new([1u8; 32]);
+pub const BOB: AccountId = AccountId32::new([2u8; 32]);
+pub const EVA: AccountId = AccountId32::new([5u8; 32]);
 pub const ID_1: LockIdentifier = *b"1       ";
 
 pub struct ExtBuilder {

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -13,7 +13,6 @@ codec = { package = "parity-scale-codec", version = "1.3.0", default-features = 
 sp-runtime = { version = "2.0.0", default-features = false }
 sp-io = { version = "2.0.0", default-features = false }
 sp-std = { version = "2.0.0", default-features = false }
-sp-core = { version = "2.0.0", default-features = false }
 
 frame-support = { version = "2.0.0", default-features = false }
 frame-system = { version = "2.0.0", default-features = false }
@@ -21,6 +20,7 @@ frame-system = { version = "2.0.0", default-features = false }
 orml-traits = { path = "../traits", version = "0.3.3-dev", default-features = false }
 
 [dev-dependencies]
+sp-core = { version = "2.0.0", default-features = false }
 pallet-treasury = { version = "2.0.0" }
 pallet-elections-phragmen = { version = "2.0.0" }
 
@@ -34,7 +34,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-io/std",
-	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 	"orml-traits/std",

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -13,6 +13,7 @@ codec = { package = "parity-scale-codec", version = "1.3.0", default-features = 
 sp-runtime = { version = "2.0.0", default-features = false }
 sp-io = { version = "2.0.0", default-features = false }
 sp-std = { version = "2.0.0", default-features = false }
+sp-core = { version = "2.0.0", default-features = false }
 
 frame-support = { version = "2.0.0", default-features = false }
 frame-system = { version = "2.0.0", default-features = false }
@@ -20,7 +21,6 @@ frame-system = { version = "2.0.0", default-features = false }
 orml-traits = { path = "../traits", version = "0.3.3-dev", default-features = false }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0", default-features = false }
 pallet-treasury = { version = "2.0.0" }
 pallet-elections-phragmen = { version = "2.0.0" }
 
@@ -34,6 +34,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-io/std",
+	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 	"orml-traits/std",

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -7,11 +7,12 @@ use frame_support::{
 	traits::{ChangeMembers, Contains, ContainsLengthBound, SaturatingCurrencyToVote},
 };
 use frame_system as system;
+use orml_traits::parameter_type_with_key;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{AccountIdConversion, IdentityLookup},
-	ModuleId, Perbill, Percent, Permill,
+	AccountId32, ModuleId, Perbill, Percent, Permill,
 };
 use sp_std::cell::RefCell;
 use std::collections::HashMap;
@@ -297,8 +298,17 @@ impl OnDust<CurrencyId, Balance> for MockOnDust {
 	}
 }
 
+parameter_type_with_key! {
+	pub ExistenceDeposits: |currency_id: CurrencyId| -> Balance {
+		match currency_id {
+			&BTC => 1,
+			&DOT => 2,
+			_ => 0,
+		}
+	};
+}
+
 parameter_types! {
-	pub ExistenceDeposits: Vec<(CurrencyId, Balance)> = vec![(BTC, 1), (DOT, 2)];
 	pub DustAccount: AccountId = ModuleId(*b"aca/dust").into_account();
 }
 
@@ -311,7 +321,6 @@ impl Trait for Runtime {
 	type WeightInfo = ();
 	type ExistenceDeposits = ExistenceDeposits;
 	type OnDust = MockOnDust;
-	type AccountIdConvert = AccountId;
 }
 pub type Tokens = Module<Runtime>;
 pub type TreasuryCurrencyAdapter = <Runtime as pallet_treasury::Trait>::Currency;

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -8,11 +8,28 @@ use frame_support::{
 };
 use frame_system as system;
 use sp_core::H256;
-use sp_runtime::{testing::Header, traits::IdentityLookup, ModuleId, Perbill, Percent, Permill};
+use sp_runtime::{
+	testing::Header,
+	traits::{AccountIdConversion, IdentityLookup},
+	ModuleId, Perbill, Percent, Permill,
+};
 use sp_std::cell::RefCell;
 use std::collections::HashMap;
 
 use super::*;
+
+pub type AccountId = AccountId32;
+pub type CurrencyId = u32;
+pub type Balance = u64;
+
+pub const DOT: CurrencyId = 1;
+pub const BTC: CurrencyId = 2;
+pub const ETH: CurrencyId = 3;
+pub const ALICE: AccountId = AccountId32::new([0u8; 32]);
+pub const BOB: AccountId = AccountId32::new([1u8; 32]);
+pub const TREASURY_ACCOUNT: AccountId = AccountId32::new([2u8; 32]);
+pub const ID_1: LockIdentifier = *b"1       ";
+pub const ID_2: LockIdentifier = *b"2       ";
 
 impl_outer_origin! {
 	pub enum Origin for Runtime {}
@@ -41,7 +58,6 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-type AccountId = u64;
 impl frame_system::Trait for Runtime {
 	type Origin = Origin;
 	type Call = ();
@@ -71,39 +87,23 @@ impl frame_system::Trait for Runtime {
 }
 pub type System = system::Module<Runtime>;
 
-type CurrencyId = u32;
-pub type Balance = u64;
-
 thread_local! {
-	pub static ACCUMULATED_RECEIVED: RefCell<HashMap<(AccountId, CurrencyId), Balance>> = RefCell::new(HashMap::new());
+	static TEN_TO_FOURTEEN: RefCell<Vec<AccountId>> = RefCell::new(vec![
+		AccountId32::new([10u8; 32]),
+		AccountId32::new([11u8; 32]),
+		AccountId32::new([12u8; 32]),
+		AccountId32::new([13u8; 32]),
+		AccountId32::new([14u8; 32]),
+	]);
 }
 
-pub struct MockOnReceived;
-impl OnReceived<AccountId, CurrencyId, Balance> for MockOnReceived {
-	fn on_received(who: &AccountId, currency_id: CurrencyId, amount: Balance) {
-		ACCUMULATED_RECEIVED.with(|v| {
-			let mut old_map = v.borrow().clone();
-			if let Some(before) = old_map.get_mut(&(*who, currency_id)) {
-				*before += amount;
-			} else {
-				old_map.insert((*who, currency_id), amount);
-			};
-
-			*v.borrow_mut() = old_map;
-		});
-	}
-}
-
-thread_local! {
-	static TEN_TO_FOURTEEN: RefCell<Vec<u64>> = RefCell::new(vec![10,11,12,13,14]);
-}
 pub struct TenToFourteen;
-impl Contains<u64> for TenToFourteen {
-	fn sorted_members() -> Vec<u64> {
+impl Contains<AccountId> for TenToFourteen {
+	fn sorted_members() -> Vec<AccountId> {
 		TEN_TO_FOURTEEN.with(|v| v.borrow().clone())
 	}
 	#[cfg(feature = "runtime-benchmarks")]
-	fn add(new: &u64) {
+	fn add(new: &AccountId) {
 		TEN_TO_FOURTEEN.with(|v| {
 			let mut members = v.borrow_mut();
 			members.push(*new);
@@ -111,6 +111,7 @@ impl Contains<u64> for TenToFourteen {
 		})
 	}
 }
+
 impl ContainsLengthBound for TenToFourteen {
 	fn max_len() -> usize {
 		TEN_TO_FOURTEEN.with(|v| v.borrow().len())
@@ -130,14 +131,14 @@ parameter_types! {
 	pub const SpendPeriod: u64 = 2;
 	pub const Burn: Permill = Permill::from_percent(50);
 	pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
-	pub const GetTokenId: CurrencyId = TEST_TOKEN_ID;
+	pub const GetTokenId: CurrencyId = DOT;
 }
 
 impl pallet_treasury::Trait for Runtime {
 	type ModuleId = TreasuryModuleId;
 	type Currency = CurrencyAdapter<Runtime, GetTokenId>;
-	type ApproveOrigin = frame_system::EnsureRoot<u64>;
-	type RejectOrigin = frame_system::EnsureRoot<u64>;
+	type ApproveOrigin = frame_system::EnsureRoot<AccountId>;
+	type RejectOrigin = frame_system::EnsureRoot<AccountId>;
 	type Tippers = TenToFourteen;
 	type TipCountdown = TipCountdown;
 	type TipFindersFee = TipFindersFee;
@@ -199,13 +200,13 @@ impl Get<u64> for TermDuration {
 }
 
 thread_local! {
-	pub static MEMBERS: RefCell<Vec<u64>> = RefCell::new(vec![]);
-	pub static PRIME: RefCell<Option<u64>> = RefCell::new(None);
+	pub static MEMBERS: RefCell<Vec<AccountId>> = RefCell::new(vec![]);
+	pub static PRIME: RefCell<Option<AccountId>> = RefCell::new(None);
 }
 
 pub struct TestChangeMembers;
-impl ChangeMembers<u64> for TestChangeMembers {
-	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) {
+impl ChangeMembers<AccountId> for TestChangeMembers {
+	fn change_members_sorted(incoming: &[AccountId], outgoing: &[AccountId], new: &[AccountId]) {
 		// new, incoming, outgoing must be sorted.
 		let mut new_sorted = new.to_vec();
 		new_sorted.sort();
@@ -241,7 +242,7 @@ impl ChangeMembers<u64> for TestChangeMembers {
 		PRIME.with(|p| *p.borrow_mut() = None);
 	}
 
-	fn set_prime(who: Option<u64>) {
+	fn set_prime(who: Option<AccountId>) {
 		PRIME.with(|p| *p.borrow_mut() = who);
 	}
 }
@@ -268,6 +269,38 @@ impl pallet_elections_phragmen::Trait for Runtime {
 	type WeightInfo = ();
 }
 
+thread_local! {
+	pub static ACCUMULATED_RECEIVED: RefCell<HashMap<(AccountId, CurrencyId), Balance>> = RefCell::new(HashMap::new());
+}
+
+pub struct MockOnReceived;
+impl OnReceived<AccountId, CurrencyId, Balance> for MockOnReceived {
+	fn on_received(who: &AccountId, currency_id: CurrencyId, amount: Balance) {
+		ACCUMULATED_RECEIVED.with(|v| {
+			let mut old_map = v.borrow().clone();
+			if let Some(before) = old_map.get_mut(&(who.clone(), currency_id)) {
+				*before += amount;
+			} else {
+				old_map.insert((who.clone(), currency_id), amount);
+			};
+
+			*v.borrow_mut() = old_map;
+		});
+	}
+}
+
+pub struct MockOnDust;
+impl OnDust<CurrencyId, Balance> for MockOnDust {
+	fn on_dust(currency_id: CurrencyId, amount: Balance) {
+		let _ = Tokens::deposit(currency_id, &DustAccount::get(), amount);
+	}
+}
+
+parameter_types! {
+	pub ExistenceDeposits: Vec<(CurrencyId, Balance)> = vec![(BTC, 1), (DOT, 2)];
+	pub DustAccount: AccountId = ModuleId(*b"aca/dust").into_account();
+}
+
 impl Trait for Runtime {
 	type Event = TestEvent;
 	type Balance = Balance;
@@ -275,18 +308,12 @@ impl Trait for Runtime {
 	type CurrencyId = CurrencyId;
 	type OnReceived = MockOnReceived;
 	type WeightInfo = ();
+	type ExistenceDeposits = ExistenceDeposits;
+	type OnDust = MockOnDust;
+	type AccountIdConvert = AccountId;
 }
-
 pub type Tokens = Module<Runtime>;
 pub type TreasuryCurrencyAdapter = <Runtime as pallet_treasury::Trait>::Currency;
-
-pub const TEST_TOKEN_ID: CurrencyId = 1;
-pub const TEST_TOKEN_ID2: CurrencyId = 2;
-pub const ALICE: AccountId = 1;
-pub const BOB: AccountId = 2;
-pub const TREASURY_ACCOUNT: AccountId = 3;
-pub const ID_1: LockIdentifier = *b"1       ";
-pub const ID_2: LockIdentifier = *b"2       ";
 
 pub struct ExtBuilder {
 	endowed_accounts: Vec<(AccountId, CurrencyId, Balance)>,
@@ -309,12 +336,17 @@ impl ExtBuilder {
 	}
 
 	pub fn one_hundred_for_alice_n_bob(self) -> Self {
-		self.balances(vec![(ALICE, TEST_TOKEN_ID, 100), (BOB, TEST_TOKEN_ID, 100)])
+		self.balances(vec![
+			(ALICE, DOT, 100),
+			(BOB, DOT, 100),
+			(ALICE, ETH, 100),
+			(BOB, ETH, 100),
+		])
 	}
 
 	pub fn one_hundred_for_treasury_account(mut self) -> Self {
 		self.treasury_genesis = true;
-		self.balances(vec![(TREASURY_ACCOUNT, TEST_TOKEN_ID, 100)])
+		self.balances(vec![(TREASURY_ACCOUNT, DOT, 100)])
 	}
 
 	pub fn build(self) -> sp_io::TestExternalities {

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -159,6 +159,7 @@ impl pallet_treasury::Trait for Runtime {
 	type MaximumReasonLength = ();
 	type WeightInfo = ();
 }
+pub type Treasury = pallet_treasury::Module<Runtime>;
 
 parameter_types! {
 	pub const CandidacyBond: u64 = 3;
@@ -336,12 +337,7 @@ impl ExtBuilder {
 	}
 
 	pub fn one_hundred_for_alice_n_bob(self) -> Self {
-		self.balances(vec![
-			(ALICE, DOT, 100),
-			(BOB, DOT, 100),
-			(ALICE, ETH, 100),
-			(BOB, ETH, 100),
-		])
+		self.balances(vec![(ALICE, DOT, 100), (BOB, DOT, 100)])
 	}
 
 	pub fn one_hundred_for_treasury_account(mut self) -> Self {

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -851,23 +851,6 @@ fn currency_adapter_lock_reasons_extension_should_work() {
 }
 
 #[test]
-fn make_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		TreasuryCurrencyAdapter::make_free_balance_be(&ALICE, 2);
-		assert_eq!(TreasuryCurrencyAdapter::total_issuance(), 2);
-		assert_eq!(TreasuryCurrencyAdapter::total_balance(&ALICE), 2);
-		assert_eq!(
-			Tokens::accounts(ALICE, DOT),
-			AccountData {
-				free: 2,
-				reserved: 0,
-				frozen: 0
-			}
-		);
-	});
-}
-
-#[test]
 fn currency_adapter_reward_should_work() {
 	ExtBuilder::default()
 		.one_hundred_for_treasury_account()

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -10,21 +10,21 @@ use mock::{
 };
 
 #[test]
-fn existential_deposit_work() {
+fn minimum_balance_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Tokens::existential_deposit(BTC), 1);
-		assert_eq!(Tokens::existential_deposit(DOT), 2);
-		assert_eq!(Tokens::existential_deposit(ETH), 0);
+		assert_eq!(Tokens::minimum_balance(BTC), 1);
+		assert_eq!(Tokens::minimum_balance(DOT), 2);
+		assert_eq!(Tokens::minimum_balance(ETH), 0);
 	});
 }
 
 #[test]
 fn is_module_account_id_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(Tokens::is_module_account_id(ALICE), false);
-		assert_eq!(Tokens::is_module_account_id(BOB), false);
-		assert_eq!(Tokens::is_module_account_id(TREASURY_ACCOUNT), false);
-		assert_eq!(Tokens::is_module_account_id(DustAccount::get()), true);
+		assert_eq!(Tokens::is_module_account_id(&ALICE), false);
+		assert_eq!(Tokens::is_module_account_id(&BOB), false);
+		assert_eq!(Tokens::is_module_account_id(&TREASURY_ACCOUNT), false);
+		assert_eq!(Tokens::is_module_account_id(&DustAccount::get()), true);
 	});
 }
 

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -5,9 +5,70 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok, traits::WithdrawReasons};
 use mock::{
-	Balance, ExtBuilder, Runtime, System, TestEvent, Tokens, TreasuryCurrencyAdapter, ACCUMULATED_RECEIVED, ALICE, BOB,
-	ID_1, ID_2, TEST_TOKEN_ID, TEST_TOKEN_ID2, TREASURY_ACCOUNT,
+	Balance, DustAccount, ExtBuilder, Runtime, System, TestEvent, Tokens, TreasuryCurrencyAdapter,
+	ACCUMULATED_RECEIVED, ALICE, BOB, BTC, DOT, ETH, ID_1, ID_2, TREASURY_ACCOUNT,
 };
+
+#[test]
+fn existential_deposit_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(Tokens::existential_deposit(BTC), 1);
+		assert_eq!(Tokens::existential_deposit(DOT), 2);
+		assert_eq!(Tokens::existential_deposit(ETH), 0);
+	});
+}
+
+#[test]
+fn is_module_account_id_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(Tokens::is_module_account_id(ALICE), false);
+		assert_eq!(Tokens::is_module_account_id(BOB), false);
+		assert_eq!(Tokens::is_module_account_id(TREASURY_ACCOUNT), false);
+		assert_eq!(Tokens::is_module_account_id(DustAccount::get()), true);
+	});
+}
+
+#[test]
+fn remove_dust_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+
+		assert_ok!(Tokens::deposit(DOT, &ALICE, 100));
+		assert_eq!(Tokens::total_issuance(DOT), 100);
+		assert_eq!(Accounts::<Runtime>::contains_key(ALICE, DOT), true);
+		assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+		assert_eq!(System::refs(&ALICE), 1);
+		assert_eq!(Accounts::<Runtime>::contains_key(DustAccount::get(), DOT), false);
+		assert_eq!(Tokens::free_balance(DOT, &DustAccount::get()), 0);
+		assert_eq!(System::refs(&DustAccount::get()), 0);
+
+		// total is gte ED, will not handle dust
+		assert_ok!(Tokens::withdraw(DOT, &ALICE, 98));
+		assert_eq!(Tokens::total_issuance(DOT), 2);
+		assert_eq!(Accounts::<Runtime>::contains_key(ALICE, DOT), true);
+		assert_eq!(Tokens::free_balance(DOT, &ALICE), 2);
+		assert_eq!(System::refs(&ALICE), 1);
+		assert_eq!(Accounts::<Runtime>::contains_key(DustAccount::get(), DOT), false);
+		assert_eq!(Tokens::free_balance(DOT, &DustAccount::get()), 0);
+		assert_eq!(System::refs(&DustAccount::get()), 0);
+
+		assert_ok!(Tokens::withdraw(DOT, &ALICE, 1));
+
+		// total is lte ED, will handle dust
+		assert_eq!(Tokens::total_issuance(DOT), 1);
+		assert_eq!(Accounts::<Runtime>::contains_key(ALICE, DOT), false);
+		assert_eq!(Tokens::free_balance(DOT, &ALICE), 0);
+		assert_eq!(System::refs(&ALICE), 0);
+
+		// will not handle dust for module account
+		assert_eq!(Accounts::<Runtime>::contains_key(DustAccount::get(), DOT), true);
+		assert_eq!(Tokens::free_balance(DOT, &DustAccount::get()), 1);
+		assert_eq!(System::refs(&DustAccount::get()), 1);
+
+		let dust_lost_event = TestEvent::tokens(RawEvent::DustLost(ALICE, DOT, 1));
+		assert!(System::events().iter().any(|record| record.event == dust_lost_event));
+	});
+}
 
 #[test]
 fn set_lock_should_work() {
@@ -15,16 +76,16 @@ fn set_lock_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 10);
-			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 10);
-			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen(), 10);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
-			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 50);
-			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 50);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
-			Tokens::set_lock(ID_2, TEST_TOKEN_ID, &ALICE, 60);
-			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 60);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 2);
+			Tokens::set_lock(ID_1, DOT, &ALICE, 10);
+			assert_eq!(Tokens::accounts(&ALICE, DOT).frozen, 10);
+			assert_eq!(Tokens::accounts(&ALICE, DOT).frozen(), 10);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 1);
+			Tokens::set_lock(ID_1, DOT, &ALICE, 50);
+			assert_eq!(Tokens::accounts(&ALICE, DOT).frozen, 50);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 1);
+			Tokens::set_lock(ID_2, DOT, &ALICE, 60);
+			assert_eq!(Tokens::accounts(&ALICE, DOT).frozen, 60);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 2);
 		});
 }
 
@@ -34,15 +95,15 @@ fn extend_lock_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 10);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
-			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 10);
-			Tokens::extend_lock(ID_1, TEST_TOKEN_ID, &ALICE, 20);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
-			assert_eq!(Tokens::accounts(&ALICE, TEST_TOKEN_ID).frozen, 20);
-			Tokens::extend_lock(ID_2, TEST_TOKEN_ID, &ALICE, 10);
-			Tokens::extend_lock(ID_1, TEST_TOKEN_ID, &ALICE, 20);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 2);
+			Tokens::set_lock(ID_1, DOT, &ALICE, 10);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 1);
+			assert_eq!(Tokens::accounts(&ALICE, DOT).frozen, 10);
+			Tokens::extend_lock(ID_1, DOT, &ALICE, 20);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 1);
+			assert_eq!(Tokens::accounts(&ALICE, DOT).frozen, 20);
+			Tokens::extend_lock(ID_2, DOT, &ALICE, 10);
+			Tokens::extend_lock(ID_1, DOT, &ALICE, 20);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 2);
 		});
 }
 
@@ -52,11 +113,11 @@ fn remove_lock_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 10);
-			Tokens::set_lock(ID_2, TEST_TOKEN_ID, &ALICE, 20);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 2);
-			Tokens::remove_lock(ID_2, TEST_TOKEN_ID, &ALICE);
-			assert_eq!(Tokens::locks(ALICE, TEST_TOKEN_ID).len(), 1);
+			Tokens::set_lock(ID_1, DOT, &ALICE, 10);
+			Tokens::set_lock(ID_2, DOT, &ALICE, 20);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 2);
+			Tokens::remove_lock(ID_2, DOT, &ALICE);
+			assert_eq!(Tokens::locks(ALICE, DOT).len(), 1);
 		});
 }
 
@@ -66,13 +127,13 @@ fn frozen_can_limit_liquidity() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 90);
+			Tokens::set_lock(ID_1, DOT, &ALICE, 90);
 			assert_noop!(
-				<Tokens as MultiCurrency<_>>::transfer(TEST_TOKEN_ID, &ALICE, &BOB, 11),
+				<Tokens as MultiCurrency<_>>::transfer(DOT, &ALICE, &BOB, 11),
 				Error::<Runtime>::LiquidityRestrictions,
 			);
-			Tokens::set_lock(ID_1, TEST_TOKEN_ID, &ALICE, 10);
-			assert_ok!(<Tokens as MultiCurrency<_>>::transfer(TEST_TOKEN_ID, &ALICE, &BOB, 11),);
+			Tokens::set_lock(ID_1, DOT, &ALICE, 10);
+			assert_ok!(<Tokens as MultiCurrency<_>>::transfer(DOT, &ALICE, &BOB, 11),);
 		});
 }
 
@@ -82,9 +143,9 @@ fn can_reserve_is_correct() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_eq!(Tokens::can_reserve(TEST_TOKEN_ID, &ALICE, 0), true);
-			assert_eq!(Tokens::can_reserve(TEST_TOKEN_ID, &ALICE, 101), false);
-			assert_eq!(Tokens::can_reserve(TEST_TOKEN_ID, &ALICE, 100), true);
+			assert_eq!(Tokens::can_reserve(DOT, &ALICE, 0), true);
+			assert_eq!(Tokens::can_reserve(DOT, &ALICE, 101), false);
+			assert_eq!(Tokens::can_reserve(DOT, &ALICE, 100), true);
 		});
 }
 
@@ -94,18 +155,15 @@ fn reserve_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_noop!(
-				Tokens::reserve(TEST_TOKEN_ID, &ALICE, 101),
-				Error::<Runtime>::BalanceTooLow,
-			);
-			assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &ALICE, 0));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::total_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &ALICE, 50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::total_balance(TEST_TOKEN_ID, &ALICE), 100);
+			assert_noop!(Tokens::reserve(DOT, &ALICE, 101), Error::<Runtime>::BalanceTooLow,);
+			assert_ok!(Tokens::reserve(DOT, &ALICE, 0));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::total_balance(DOT, &ALICE), 100);
+			assert_ok!(Tokens::reserve(DOT, &ALICE, 50));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::total_balance(DOT, &ALICE), 100);
 		});
 }
 
@@ -115,19 +173,19 @@ fn unreserve_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::unreserve(TEST_TOKEN_ID, &ALICE, 0), 0);
-			assert_eq!(Tokens::unreserve(TEST_TOKEN_ID, &ALICE, 50), 50);
-			assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &ALICE, 30));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 70);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 30);
-			assert_eq!(Tokens::unreserve(TEST_TOKEN_ID, &ALICE, 15), 0);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 85);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 15);
-			assert_eq!(Tokens::unreserve(TEST_TOKEN_ID, &ALICE, 30), 15);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::unreserve(DOT, &ALICE, 0), 0);
+			assert_eq!(Tokens::unreserve(DOT, &ALICE, 50), 50);
+			assert_ok!(Tokens::reserve(DOT, &ALICE, 30));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 70);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 30);
+			assert_eq!(Tokens::unreserve(DOT, &ALICE, 15), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 85);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 15);
+			assert_eq!(Tokens::unreserve(DOT, &ALICE, 30), 15);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
 		});
 }
 
@@ -137,18 +195,18 @@ fn slash_reserved_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &ALICE, 50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
-			assert_eq!(Tokens::slash_reserved(TEST_TOKEN_ID, &ALICE, 0), 0);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
-			assert_eq!(Tokens::slash_reserved(TEST_TOKEN_ID, &ALICE, 100), 50);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 150);
+			assert_ok!(Tokens::reserve(DOT, &ALICE, 50));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::total_issuance(DOT), 200);
+			assert_eq!(Tokens::slash_reserved(DOT, &ALICE, 0), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::total_issuance(DOT), 200);
+			assert_eq!(Tokens::slash_reserved(DOT, &ALICE, 100), 50);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::total_issuance(DOT), 150);
 		});
 }
 
@@ -158,48 +216,48 @@ fn repatriate_reserved_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
 			assert_eq!(
-				Tokens::repatriate_reserved(TEST_TOKEN_ID, &ALICE, &ALICE, 0, BalanceStatus::Free),
+				Tokens::repatriate_reserved(DOT, &ALICE, &ALICE, 0, BalanceStatus::Free),
 				Ok(0)
 			);
 			assert_eq!(
-				Tokens::repatriate_reserved(TEST_TOKEN_ID, &ALICE, &ALICE, 50, BalanceStatus::Free),
+				Tokens::repatriate_reserved(DOT, &ALICE, &ALICE, 50, BalanceStatus::Free),
 				Ok(50)
 			);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
 
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 100);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &BOB), 0);
-			assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &BOB, 50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &BOB), 50);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 100);
+			assert_eq!(Tokens::reserved_balance(DOT, &BOB), 0);
+			assert_ok!(Tokens::reserve(DOT, &BOB, 50));
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &BOB), 50);
 			assert_eq!(
-				Tokens::repatriate_reserved(TEST_TOKEN_ID, &BOB, &BOB, 60, BalanceStatus::Reserved),
+				Tokens::repatriate_reserved(DOT, &BOB, &BOB, 60, BalanceStatus::Reserved),
 				Ok(10)
 			);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &BOB), 50);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &BOB), 50);
 
 			assert_eq!(
-				Tokens::repatriate_reserved(TEST_TOKEN_ID, &BOB, &ALICE, 30, BalanceStatus::Reserved),
+				Tokens::repatriate_reserved(DOT, &BOB, &ALICE, 30, BalanceStatus::Reserved),
 				Ok(0)
 			);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 30);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &BOB), 20);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 30);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &BOB), 20);
 
 			assert_eq!(
-				Tokens::repatriate_reserved(TEST_TOKEN_ID, &BOB, &ALICE, 30, BalanceStatus::Free),
+				Tokens::repatriate_reserved(DOT, &BOB, &ALICE, 30, BalanceStatus::Free),
 				Ok(10)
 			);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 120);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 30);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &BOB), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 120);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 30);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &BOB), 0);
 		});
 }
 
@@ -209,20 +267,20 @@ fn slash_draw_reserved_correct() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &ALICE, 50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
+			assert_ok!(Tokens::reserve(DOT, &ALICE, 50));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::total_issuance(DOT), 200);
 
-			assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 80), 0);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 20);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 120);
+			assert_eq!(Tokens::slash(DOT, &ALICE, 80), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 20);
+			assert_eq!(Tokens::total_issuance(DOT), 120);
 
-			assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 50), 30);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 100);
+			assert_eq!(Tokens::slash(DOT, &ALICE, 50), 30);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::total_issuance(DOT), 100);
 		});
 }
 
@@ -232,9 +290,9 @@ fn genesis_issuance_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 100);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 100);
+			assert_eq!(Tokens::total_issuance(DOT), 200);
 		});
 }
 
@@ -246,20 +304,17 @@ fn transfer_should_work() {
 		.execute_with(|| {
 			System::set_block_number(1);
 
-			assert_ok!(Tokens::transfer(Some(ALICE).into(), BOB, TEST_TOKEN_ID, 50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 150);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
-			assert_eq!(
-				ACCUMULATED_RECEIVED.with(|v| *v.borrow().get(&(BOB, TEST_TOKEN_ID)).unwrap()),
-				50
-			);
+			assert_ok!(Tokens::transfer(Some(ALICE).into(), BOB, DOT, 50));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 150);
+			assert_eq!(Tokens::total_issuance(DOT), 200);
+			assert_eq!(ACCUMULATED_RECEIVED.with(|v| *v.borrow().get(&(BOB, DOT)).unwrap()), 50);
 
-			let transferred_event = TestEvent::tokens(RawEvent::Transferred(TEST_TOKEN_ID, ALICE, BOB, 50));
+			let transferred_event = TestEvent::tokens(RawEvent::Transferred(DOT, ALICE, BOB, 50));
 			assert!(System::events().iter().any(|record| record.event == transferred_event));
 
 			assert_noop!(
-				Tokens::transfer(Some(ALICE).into(), BOB, TEST_TOKEN_ID, 60),
+				Tokens::transfer(Some(ALICE).into(), BOB, DOT, 60),
 				Error::<Runtime>::BalanceTooLow,
 			);
 		});
@@ -273,11 +328,11 @@ fn transfer_all_should_work() {
 		.execute_with(|| {
 			System::set_block_number(1);
 
-			assert_ok!(Tokens::transfer_all(Some(ALICE).into(), BOB, TEST_TOKEN_ID));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 200);
+			assert_ok!(Tokens::transfer_all(Some(ALICE).into(), BOB, DOT));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 200);
 
-			let transferred_event = TestEvent::tokens(RawEvent::Transferred(TEST_TOKEN_ID, ALICE, BOB, 100));
+			let transferred_event = TestEvent::tokens(RawEvent::Transferred(DOT, ALICE, BOB, 100));
 			assert!(System::events().iter().any(|record| record.event == transferred_event));
 		});
 }
@@ -288,12 +343,12 @@ fn deposit_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_ok!(Tokens::deposit(TEST_TOKEN_ID, &ALICE, 100));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 200);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 300);
+			assert_ok!(Tokens::deposit(DOT, &ALICE, 100));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 200);
+			assert_eq!(Tokens::total_issuance(DOT), 300);
 
 			assert_noop!(
-				Tokens::deposit(TEST_TOKEN_ID, &ALICE, Balance::max_value()),
+				Tokens::deposit(DOT, &ALICE, Balance::max_value()),
 				Error::<Runtime>::TotalIssuanceOverflow,
 			);
 		});
@@ -305,14 +360,11 @@ fn withdraw_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_ok!(Tokens::withdraw(TEST_TOKEN_ID, &ALICE, 50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 150);
+			assert_ok!(Tokens::withdraw(DOT, &ALICE, 50));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::total_issuance(DOT), 150);
 
-			assert_noop!(
-				Tokens::withdraw(TEST_TOKEN_ID, &ALICE, 60),
-				Error::<Runtime>::BalanceTooLow
-			);
+			assert_noop!(Tokens::withdraw(DOT, &ALICE, 60), Error::<Runtime>::BalanceTooLow);
 		});
 }
 
@@ -323,14 +375,14 @@ fn slash_should_work() {
 		.build()
 		.execute_with(|| {
 			// slashed_amount < amount
-			assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 50), 0);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 50);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 150);
+			assert_eq!(Tokens::slash(DOT, &ALICE, 50), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
+			assert_eq!(Tokens::total_issuance(DOT), 150);
 
 			// slashed_amount == amount
-			assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 51), 1);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 100);
+			assert_eq!(Tokens::slash(DOT, &ALICE, 51), 1);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::total_issuance(DOT), 100);
 		});
 }
 
@@ -340,18 +392,15 @@ fn update_balance_should_work() {
 		.one_hundred_for_alice_n_bob()
 		.build()
 		.execute_with(|| {
-			assert_ok!(Tokens::update_balance(TEST_TOKEN_ID, &ALICE, 50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 150);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 250);
+			assert_ok!(Tokens::update_balance(DOT, &ALICE, 50));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 150);
+			assert_eq!(Tokens::total_issuance(DOT), 250);
 
-			assert_ok!(Tokens::update_balance(TEST_TOKEN_ID, &BOB, -50));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 50);
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
+			assert_ok!(Tokens::update_balance(DOT, &BOB, -50));
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);
+			assert_eq!(Tokens::total_issuance(DOT), 200);
 
-			assert_noop!(
-				Tokens::update_balance(TEST_TOKEN_ID, &BOB, -60),
-				Error::<Runtime>::BalanceTooLow
-			);
+			assert_noop!(Tokens::update_balance(DOT, &BOB, -60), Error::<Runtime>::BalanceTooLow);
 		});
 }
 
@@ -362,51 +411,51 @@ fn ensure_can_withdraw_should_work() {
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				Tokens::ensure_can_withdraw(TEST_TOKEN_ID, &ALICE, 101),
+				Tokens::ensure_can_withdraw(DOT, &ALICE, 101),
 				Error::<Runtime>::BalanceTooLow
 			);
 
-			assert_ok!(Tokens::ensure_can_withdraw(TEST_TOKEN_ID, &ALICE, 1));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
+			assert_ok!(Tokens::ensure_can_withdraw(DOT, &ALICE, 1));
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
 		});
 }
 
 #[test]
 fn no_op_if_amount_is_zero() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(Tokens::ensure_can_withdraw(TEST_TOKEN_ID, &ALICE, 0));
-		assert_ok!(Tokens::transfer(Some(ALICE).into(), BOB, TEST_TOKEN_ID, 0));
-		assert_ok!(Tokens::transfer(Some(ALICE).into(), ALICE, TEST_TOKEN_ID, 0));
-		assert_ok!(Tokens::deposit(TEST_TOKEN_ID, &ALICE, 0));
-		assert_ok!(Tokens::withdraw(TEST_TOKEN_ID, &ALICE, 0));
-		assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 0), 0);
-		assert_eq!(Tokens::slash(TEST_TOKEN_ID, &ALICE, 1), 1);
-		assert_ok!(Tokens::update_balance(TEST_TOKEN_ID, &ALICE, 0));
+		assert_ok!(Tokens::ensure_can_withdraw(DOT, &ALICE, 0));
+		assert_ok!(Tokens::transfer(Some(ALICE).into(), BOB, DOT, 0));
+		assert_ok!(Tokens::transfer(Some(ALICE).into(), ALICE, DOT, 0));
+		assert_ok!(Tokens::deposit(DOT, &ALICE, 0));
+		assert_ok!(Tokens::withdraw(DOT, &ALICE, 0));
+		assert_eq!(Tokens::slash(DOT, &ALICE, 0), 0);
+		assert_eq!(Tokens::slash(DOT, &ALICE, 1), 1);
+		assert_ok!(Tokens::update_balance(DOT, &ALICE, 0));
 	});
 }
 
 #[test]
 fn merge_account_should_work() {
 	ExtBuilder::default()
-		.balances(vec![(ALICE, TEST_TOKEN_ID, 100), (ALICE, TEST_TOKEN_ID2, 200)])
+		.balances(vec![(ALICE, DOT, 100), (ALICE, BTC, 200)])
 		.build()
 		.execute_with(|| {
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID2, &ALICE), 200);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 0);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
+			assert_eq!(Tokens::free_balance(BTC, &ALICE), 200);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 0);
 
-			assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &ALICE, 1));
+			assert_ok!(Tokens::reserve(DOT, &ALICE, 1));
 			assert_noop!(
 				Tokens::merge_account(&ALICE, &BOB),
 				Error::<Runtime>::StillHasActiveReserved
 			);
-			Tokens::unreserve(TEST_TOKEN_ID, &ALICE, 1);
+			Tokens::unreserve(DOT, &ALICE, 1);
 
 			assert_ok!(Tokens::merge_account(&ALICE, &BOB));
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 0);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID2, &ALICE), 0);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 100);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID2, &BOB), 200);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 0);
+			assert_eq!(Tokens::free_balance(BTC, &ALICE), 0);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 100);
+			assert_eq!(Tokens::free_balance(BTC, &BOB), 200);
 		});
 }
 
@@ -416,11 +465,11 @@ fn currency_adapter_ensure_currency_adapter_should_work() {
 		.one_hundred_for_treasury_account()
 		.build()
 		.execute_with(|| {
-			assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 100);
-			assert_eq!(Tokens::total_balance(TEST_TOKEN_ID, &TREASURY_ACCOUNT), 100);
+			assert_eq!(Tokens::total_issuance(DOT), 100);
+			assert_eq!(Tokens::total_balance(DOT, &TREASURY_ACCOUNT), 100);
 			// CandidacyBond = 3 VotingBond = 2
-			assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &TREASURY_ACCOUNT), 5);
-			assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &TREASURY_ACCOUNT), 95);
+			assert_eq!(Tokens::reserved_balance(DOT, &TREASURY_ACCOUNT), 5);
+			assert_eq!(Tokens::free_balance(DOT, &TREASURY_ACCOUNT), 95);
 			assert_eq!(
 				<Runtime as pallet_elections_phragmen::Trait>::Currency::total_balance(&TREASURY_ACCOUNT),
 				100
@@ -597,7 +646,7 @@ fn currency_adapter_deducting_balance_should_work() {
 fn currency_adapter_refunding_balance_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let _ = TreasuryCurrencyAdapter::deposit_creating(&TREASURY_ACCOUNT, 42);
-		Tokens::set_reserved_balance(TEST_TOKEN_ID, &TREASURY_ACCOUNT, 69);
+		Tokens::set_reserved_balance(DOT, &TREASURY_ACCOUNT, 69);
 		TreasuryCurrencyAdapter::unreserve(&TREASURY_ACCOUNT, 69);
 		assert_eq!(TreasuryCurrencyAdapter::free_balance(&TREASURY_ACCOUNT), 111);
 		assert_eq!(TreasuryCurrencyAdapter::reserved_balance(&TREASURY_ACCOUNT), 0);
@@ -842,7 +891,7 @@ fn currency_adapter_slashing_incomplete_reserved_balance_should_work() {
 fn currency_adapter_repatriating_reserved_balance_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let _ = TreasuryCurrencyAdapter::deposit_creating(&TREASURY_ACCOUNT, 110);
-		let _ = TreasuryCurrencyAdapter::deposit_creating(&ALICE, 1);
+		let _ = TreasuryCurrencyAdapter::deposit_creating(&ALICE, 2);
 		assert_ok!(TreasuryCurrencyAdapter::reserve(&TREASURY_ACCOUNT, 110));
 		assert_ok!(
 			TreasuryCurrencyAdapter::repatriate_reserved(&TREASURY_ACCOUNT, &ALICE, 41, Status::Free),
@@ -851,7 +900,7 @@ fn currency_adapter_repatriating_reserved_balance_should_work() {
 		assert_eq!(TreasuryCurrencyAdapter::reserved_balance(&TREASURY_ACCOUNT), 69);
 		assert_eq!(TreasuryCurrencyAdapter::free_balance(&TREASURY_ACCOUNT), 0);
 		assert_eq!(TreasuryCurrencyAdapter::reserved_balance(&ALICE), 0);
-		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 42);
+		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 43);
 	});
 }
 
@@ -859,7 +908,7 @@ fn currency_adapter_repatriating_reserved_balance_should_work() {
 fn currency_adapter_transferring_reserved_balance_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let _ = TreasuryCurrencyAdapter::deposit_creating(&TREASURY_ACCOUNT, 110);
-		let _ = TreasuryCurrencyAdapter::deposit_creating(&ALICE, 1);
+		let _ = TreasuryCurrencyAdapter::deposit_creating(&ALICE, 2);
 		assert_ok!(TreasuryCurrencyAdapter::reserve(&TREASURY_ACCOUNT, 110));
 		assert_ok!(
 			TreasuryCurrencyAdapter::repatriate_reserved(&TREASURY_ACCOUNT, &ALICE, 41, Status::Reserved),
@@ -868,7 +917,7 @@ fn currency_adapter_transferring_reserved_balance_should_work() {
 		assert_eq!(TreasuryCurrencyAdapter::reserved_balance(&TREASURY_ACCOUNT), 69);
 		assert_eq!(TreasuryCurrencyAdapter::free_balance(&TREASURY_ACCOUNT), 0);
 		assert_eq!(TreasuryCurrencyAdapter::reserved_balance(&ALICE), 41);
-		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 1);
+		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 2);
 	});
 }
 
@@ -890,7 +939,7 @@ fn currency_adapter_transferring_reserved_balance_to_nonexistent_should_fail() {
 fn currency_adapter_transferring_incomplete_reserved_balance_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let _ = TreasuryCurrencyAdapter::deposit_creating(&TREASURY_ACCOUNT, 110);
-		let _ = TreasuryCurrencyAdapter::deposit_creating(&ALICE, 1);
+		let _ = TreasuryCurrencyAdapter::deposit_creating(&ALICE, 2);
 		assert_ok!(TreasuryCurrencyAdapter::reserve(&TREASURY_ACCOUNT, 41));
 		assert_ok!(
 			TreasuryCurrencyAdapter::repatriate_reserved(&TREASURY_ACCOUNT, &ALICE, 69, Status::Free),
@@ -899,7 +948,7 @@ fn currency_adapter_transferring_incomplete_reserved_balance_should_work() {
 		assert_eq!(TreasuryCurrencyAdapter::reserved_balance(&TREASURY_ACCOUNT), 0);
 		assert_eq!(TreasuryCurrencyAdapter::free_balance(&TREASURY_ACCOUNT), 69);
 		assert_eq!(TreasuryCurrencyAdapter::reserved_balance(&ALICE), 0);
-		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 42);
+		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 43);
 	});
 }
 
@@ -907,7 +956,7 @@ fn currency_adapter_transferring_incomplete_reserved_balance_should_work() {
 fn currency_adapter_transferring_too_high_value_should_not_panic() {
 	ExtBuilder::default().build().execute_with(|| {
 		TreasuryCurrencyAdapter::make_free_balance_be(&TREASURY_ACCOUNT, u64::max_value());
-		TreasuryCurrencyAdapter::make_free_balance_be(&ALICE, 1);
+		TreasuryCurrencyAdapter::make_free_balance_be(&ALICE, 2);
 
 		assert_noop!(
 			TreasuryCurrencyAdapter::transfer(
@@ -923,6 +972,6 @@ fn currency_adapter_transferring_too_high_value_should_not_panic() {
 			TreasuryCurrencyAdapter::free_balance(&TREASURY_ACCOUNT),
 			u64::max_value()
 		);
-		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 1);
+		assert_eq!(TreasuryCurrencyAdapter::free_balance(&ALICE), 2);
 	});
 }

--- a/traits/src/currency.rs
+++ b/traits/src/currency.rs
@@ -335,7 +335,3 @@ pub trait OnReceived<AccountId, CurrencyId, Balance> {
 pub trait OnDust<CurrencyId, Balance> {
 	fn on_dust(currency_id: CurrencyId, amount: Balance);
 }
-
-impl<CurrencyId, Balance> OnDust<CurrencyId, Balance> for () {
-	fn on_dust(_: CurrencyId, _: Balance) {}
-}

--- a/traits/src/currency.rs
+++ b/traits/src/currency.rs
@@ -22,6 +22,9 @@ pub trait MultiCurrency<AccountId> {
 
 	// Public immutables
 
+	/// Existential deposit of `currency_id`.
+	fn minimum_balance(currency_id: Self::CurrencyId) -> Self::Balance;
+
 	/// The total amount of issuance of `currency_id`.
 	fn total_issuance(currency_id: Self::CurrencyId) -> Self::Balance;
 
@@ -177,6 +180,9 @@ pub trait BasicCurrency<AccountId> {
 
 	// Public immutables
 
+	/// Existential deposit.
+	fn minimum_balance() -> Self::Balance;
+
 	/// The total amount of issuance.
 	fn total_issuance() -> Self::Balance;
 
@@ -322,4 +328,14 @@ pub trait BasicReservableCurrency<AccountId>: BasicCurrency<AccountId> {
 pub trait OnReceived<AccountId, CurrencyId, Balance> {
 	/// An account have received some assets
 	fn on_received(account: &AccountId, currency: CurrencyId, amount: Balance);
+}
+
+/// Handler for when some currency "account" decreased in balance for some
+/// reason.
+pub trait OnDust<CurrencyId, Balance> {
+	fn on_dust(currency_id: CurrencyId, amount: Balance);
+}
+
+impl<CurrencyId, Balance> OnDust<CurrencyId, Balance> for () {
+	fn on_dust(_: CurrencyId, _: Balance) {}
 }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
 pub use currency::{
 	BalanceStatus, BasicCurrency, BasicCurrencyExtended, BasicLockableCurrency, BasicReservableCurrency,
-	LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency, OnReceived,
+	LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency, OnDust,
+	OnReceived,
 };
 pub use data_provider::{DataFeeder, DataProvider, DataProviderExtended};
 pub use get_by_key::GetByKey;


### PR DESCRIPTION
close #324 

1. handle dust for these accounts which total is below `ExistantialDeposit` except for module accounts(treat module account as system account).
2. use `mutate_exist` to replace `mutate` to update AccountData storage so that remove those account whose total is 0.
3. Increase/decrease ref count when adding/removing AccountData storage.