### PR TITLE
refactor try_mutate_account

### DIFF
--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -113,7 +113,6 @@ impl tokens::Trait for Runtime {
 	type Balance = Balance;
 	type Amount = i64;
 	type CurrencyId = CurrencyId;
-	type OnReceived = ();
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = MockOnDust;

--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -92,9 +92,9 @@ impl pallet_balances::Trait for Runtime {
 pub type PalletBalances = pallet_balances::Module<Runtime>;
 
 pub struct MockOnDust;
-impl OnDust<CurrencyId, Balance> for MockOnDust {
-	fn on_dust(currency_id: CurrencyId, amount: Balance) {
-		let _ = Tokens::deposit(currency_id, &DustAccount::get(), amount);
+impl OnDust<AccountId, CurrencyId, Balance> for MockOnDust {
+	fn on_dust(who: &AccountId, currency_id: CurrencyId, amount: Balance) {
+		let _ = <Tokens as MultiCurrency<_>>::transfer(currency_id, who, &DustAccount::get(), amount);
 	}
 }
 

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -15,7 +15,6 @@ use sp_runtime::{
 	AccountId32, ModuleId, Perbill, Percent, Permill,
 };
 use sp_std::cell::RefCell;
-use std::collections::HashMap;
 
 use super::*;
 
@@ -271,26 +270,6 @@ impl pallet_elections_phragmen::Trait for Runtime {
 	type WeightInfo = ();
 }
 
-thread_local! {
-	pub static ACCUMULATED_RECEIVED: RefCell<HashMap<(AccountId, CurrencyId), Balance>> = RefCell::new(HashMap::new());
-}
-
-pub struct MockOnReceived;
-impl OnReceived<AccountId, CurrencyId, Balance> for MockOnReceived {
-	fn on_received(who: &AccountId, currency_id: CurrencyId, amount: Balance) {
-		ACCUMULATED_RECEIVED.with(|v| {
-			let mut old_map = v.borrow().clone();
-			if let Some(before) = old_map.get_mut(&(who.clone(), currency_id)) {
-				*before += amount;
-			} else {
-				old_map.insert((who.clone(), currency_id), amount);
-			};
-
-			*v.borrow_mut() = old_map;
-		});
-	}
-}
-
 pub struct MockOnDust;
 impl OnDust<AccountId, CurrencyId, Balance> for MockOnDust {
 	fn on_dust(who: &AccountId, currency_id: CurrencyId, amount: Balance) {
@@ -317,7 +296,6 @@ impl Trait for Runtime {
 	type Balance = Balance;
 	type Amount = i64;
 	type CurrencyId = CurrencyId;
-	type OnReceived = MockOnReceived;
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = MockOnDust;

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -292,9 +292,9 @@ impl OnReceived<AccountId, CurrencyId, Balance> for MockOnReceived {
 }
 
 pub struct MockOnDust;
-impl OnDust<CurrencyId, Balance> for MockOnDust {
-	fn on_dust(currency_id: CurrencyId, amount: Balance) {
-		let _ = Tokens::deposit(currency_id, &DustAccount::get(), amount);
+impl OnDust<AccountId, CurrencyId, Balance> for MockOnDust {
+	fn on_dust(who: &AccountId, currency_id: CurrencyId, amount: Balance) {
+		let _ = <Tokens as MultiCurrency<_>>::transfer(currency_id, who, &DustAccount::get(), amount);
 	}
 }
 

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -5,8 +5,8 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok, traits::WithdrawReasons};
 use mock::{
-	Balance, DustAccount, ExtBuilder, Runtime, System, TestEvent, Tokens, Treasury, TreasuryCurrencyAdapter,
-	ACCUMULATED_RECEIVED, ALICE, BOB, BTC, DOT, ETH, ID_1, ID_2, TREASURY_ACCOUNT,
+	Balance, DustAccount, ExtBuilder, Runtime, System, TestEvent, Tokens, Treasury, TreasuryCurrencyAdapter, ALICE,
+	BOB, BTC, DOT, ETH, ID_1, ID_2, TREASURY_ACCOUNT,
 };
 
 #[test]
@@ -308,7 +308,6 @@ fn transfer_should_work() {
 			assert_eq!(Tokens::free_balance(DOT, &ALICE), 50);
 			assert_eq!(Tokens::free_balance(DOT, &BOB), 150);
 			assert_eq!(Tokens::total_issuance(DOT), 200);
-			assert_eq!(ACCUMULATED_RECEIVED.with(|v| *v.borrow().get(&(BOB, DOT)).unwrap()), 50);
 
 			let transferred_event = TestEvent::tokens(RawEvent::Transferred(DOT, ALICE, BOB, 50));
 			assert!(System::events().iter().any(|record| record.event == transferred_event));

--- a/traits/src/currency.rs
+++ b/traits/src/currency.rs
@@ -323,13 +323,6 @@ pub trait BasicReservableCurrency<AccountId>: BasicCurrency<AccountId> {
 	) -> result::Result<Self::Balance, DispatchError>;
 }
 
-/// Handler when an account received some assets
-#[impl_trait_for_tuples::impl_for_tuples(30)]
-pub trait OnReceived<AccountId, CurrencyId, Balance> {
-	/// An account have received some assets
-	fn on_received(account: &AccountId, currency: CurrencyId, amount: Balance);
-}
-
 /// Handler for account which has dust, need to burn or recycle it
 pub trait OnDust<AccountId, CurrencyId, Balance> {
 	fn on_dust(who: &AccountId, currency_id: CurrencyId, amount: Balance);

--- a/traits/src/currency.rs
+++ b/traits/src/currency.rs
@@ -330,12 +330,11 @@ pub trait OnReceived<AccountId, CurrencyId, Balance> {
 	fn on_received(account: &AccountId, currency: CurrencyId, amount: Balance);
 }
 
-/// Handler for when some currency "account" decreased in balance for some
-/// reason.
-pub trait OnDust<CurrencyId, Balance> {
-	fn on_dust(currency_id: CurrencyId, amount: Balance);
+/// Handler for account which has dust, need to burn or recycle it
+pub trait OnDust<AccountId, CurrencyId, Balance> {
+	fn on_dust(who: &AccountId, currency_id: CurrencyId, amount: Balance);
 }
 
-impl<CurrencyId, Balance> OnDust<CurrencyId, Balance> for () {
-	fn on_dust(_: CurrencyId, _: Balance) {}
+impl<AccountId, CurrencyId, Balance> OnDust<AccountId, CurrencyId, Balance> for () {
+	fn on_dust(_: &AccountId, _: CurrencyId, _: Balance) {}
 }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -14,7 +14,6 @@ pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
 pub use currency::{
 	BalanceStatus, BasicCurrency, BasicCurrencyExtended, BasicLockableCurrency, BasicReservableCurrency,
 	LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency, OnDust,
-	OnReceived,
 };
 pub use data_provider::{DataFeeder, DataProvider, DataProviderExtended};
 pub use get_by_key::GetByKey;


### PR DESCRIPTION
Now trigger `OnDust` after  mutate  operation for storage `Accounts`, `OnDust` can decide to burn or transfer the dust. 

And remove `OnReceived`.