### PR TITLE
Add genesis config for nft

### DIFF
--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -8,20 +8,22 @@ authors = ["Acala Developers"]
 edition = "2018"
 
 [dependencies]
+serde = { version = "1.0.111", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-std = {  version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
-sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
+sp-std = {  version = "2.0.0", default-features = false }
+sp-runtime = { version = "2.0.0", default-features = false }
 
-frame-support = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
-frame-system = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
+frame-support = { version = "2.0.0", default-features = false }
+frame-system = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]
-sp-io = {  version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
+sp-io = {  version = "2.0.0", default-features = false }
+sp-core = { version = "2.0.0", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"serde",
 	"codec/std",
 	"sp-std/std",
 	"sp-runtime/std",

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.111", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-std = {  version = "2.0.0", default-features = false }
+sp-std = { version = "2.0.0", default-features = false }
 sp-runtime = { version = "2.0.0", default-features = false }
 
 frame-support = { version = "2.0.0", default-features = false }
 frame-system = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]
-sp-io = {  version = "2.0.0", default-features = false }
+sp-io = { version = "2.0.0", default-features = false }
 sp-core = { version = "2.0.0", default-features = false }
 
 [features]

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -9,15 +9,15 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-std = { version = "2.0.0", default-features = false }
-sp-runtime = { version = "2.0.0", default-features = false }
+sp-std = {  version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
+sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
 
-frame-support = { version = "2.0.0", default-features = false }
-frame-system = { version = "2.0.0", default-features = false }
+frame-support = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
+frame-system = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
 
 [dev-dependencies]
-sp-io = { version = "2.0.0", default-features = false }
-sp-core = { version = "2.0.0", default-features = false }
+sp-io = {  version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
+sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "b2750359" }
 
 [features]
 default = ["std"]

--- a/nft/src/lib.rs
+++ b/nft/src/lib.rs
@@ -91,12 +91,6 @@ pub type ClassInfoOf<T> =
 	ClassInfo<<T as Config>::TokenId, <T as frame_system::Config>::AccountId, <T as Config>::ClassData>;
 pub type TokenInfoOf<T> = TokenInfo<<T as frame_system::Config>::AccountId, <T as Config>::TokenData>;
 
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
-pub struct NftGenesisConfig<AccountId, ClassData, TokenData> {
-
-    pub tokenList: BTreeMap<AccountId, BTreeMap<(Vec<u8>, ClassData), Vec<(Vec<u8>, TokenData)>>>
-}
-
 decl_storage! {
 	trait Store for Module<T: Config> as NonFungibleToken {
 		/// Next available class ID.

--- a/nft/src/lib.rs
+++ b/nft/src/lib.rs
@@ -92,15 +92,15 @@ pub type ClassInfoOf<T> =
 pub type TokenInfoOf<T> = TokenInfo<<T as frame_system::Config>::AccountId, <T as Config>::TokenData>;
 
 pub type GenesisTokenData<T> = (
-	<T as frame_system::Config>::AccountId,
-	Vec<u8>,
+	<T as frame_system::Config>::AccountId, // Token owner
+	Vec<u8>,                                // Token metadata
 	<T as Config>::TokenData,
 );
 pub type GenesisTokens<T> = (
-	<T as frame_system::Config>::AccountId,
-	Vec<u8>,
+	<T as frame_system::Config>::AccountId, // Token class owner
+	Vec<u8>,                                // Token class metadata
 	<T as Config>::ClassData,
-	Vec<GenesisTokenData<T>>,
+	Vec<GenesisTokenData<T>>, // Vector of tokens belonging to this class
 );
 
 decl_storage! {

--- a/nft/src/lib.rs
+++ b/nft/src/lib.rs
@@ -121,18 +121,12 @@ decl_storage! {
 
 		build(|config: &GenesisConfig<T>| {
 			config.endowed_accounts.iter().for_each(|(class_data, tokens)| {
-				let result = Module::<T>::create_class(&class_data.0, class_data.1.to_vec(), class_data.2.clone());
-				let class_id = match result {
-					Ok(class_id) => class_id,
-					_ => return,
-				};
+				let class_id = Module::<T>::create_class(&class_data.0, class_data.1.to_vec(), class_data.2.clone())
+					.expect("Create class cannot fail while building genesis");
 				for (account_id, tokens_data) in tokens {
 					for (token_metadata, token_data) in tokens_data {
-						let _result = Module::<T>::mint(&account_id, class_id, token_metadata.to_vec(), token_data.clone());
-						let _token_id = match result {
-							Ok(_token_id) => (),
-							_ => return,
-						};
+						Module::<T>::mint(&account_id, class_id, token_metadata.to_vec(), token_data.clone())
+							.expect("Token mint cannot fail during genesis");
 					}
 				}
 			})


### PR DESCRIPTION
The initial idea for a genesis config of the NFT pallet. The config accepts `BTreeMap<T::AccountId, BTreeMap<(Vec<u8>, T::ClassData), Vec<(Vec<u8>, T::TokenData)>>>` that basically says each account has a map where the key is a vector of tuples for token class data (metadata and ClassData) with the value of vector of tokens to be minted. 
However, I can't get this code built, so I will appreciate any help with finishing this PR

```
   Compiling orml-nft v0.3.5-dev (/home/pmensik/work/polkadot/open-runtime-module-library/nft)
error[E0463]: can't find crate for `serde`
   --> src/lib.rs:100:1
    |
100 | / decl_storage! {
101 | |     trait Store for Module<T: Config> as NonFungibleToken {
102 | |         /// Next available class ID.
103 | |         pub NextClassId get(fn next_class_id): T::ClassId;
...   |
161 | |     }
162 | | }
    | |_^ can't find crate
    |
```