### PR TITLE
Apply some new pallet macro conventions

### DIFF
--- a/auction/src/lib.rs
+++ b/auction/src/lib.rs
@@ -13,6 +13,14 @@
 #![allow(clippy::string_lit_as_bytes)]
 #![allow(clippy::unused_unit)]
 
+use frame_support::pallet_prelude::*;
+use frame_system::{ensure_signed, pallet_prelude::*};
+use orml_traits::{Auction, AuctionHandler, AuctionInfo, Change};
+use sp_runtime::{
+	traits::{AtLeast32BitUnsigned, Bounded, MaybeSerializeDeserialize, Member, One, Zero},
+	DispatchError, DispatchResult,
+};
+
 mod default_weight;
 mod mock;
 mod tests;
@@ -21,13 +29,7 @@ pub use module::*;
 
 #[frame_support::pallet]
 pub mod module {
-	use frame_support::pallet_prelude::*;
-	use frame_system::{ensure_signed, pallet_prelude::*};
-	use orml_traits::{Auction, AuctionHandler, AuctionInfo, Change};
-	use sp_runtime::{
-		traits::{AtLeast32BitUnsigned, Bounded, MaybeSerializeDeserialize, Member, One, Zero},
-		DispatchError, DispatchResult,
-	};
+	use super::*;
 
 	pub trait WeightInfo {
 		fn bid_collateral_auction() -> Weight;
@@ -77,20 +79,20 @@ pub mod module {
 		Bid(T::AuctionId, T::AccountId, T::Balance),
 	}
 
+	/// Stores on-going and future auctions. Closed auction are removed.
 	#[pallet::storage]
 	#[pallet::getter(fn auctions)]
-	/// Stores on-going and future auctions. Closed auction are removed.
 	pub type Auctions<T: Config> =
 		StorageMap<_, Twox64Concat, T::AuctionId, AuctionInfo<T::AccountId, T::Balance, T::BlockNumber>, OptionQuery>;
 
+	/// Track the next auction ID.
 	#[pallet::storage]
 	#[pallet::getter(fn auctions_index)]
-	/// Track the next auction ID.
 	pub type AuctionsIndex<T: Config> = StorageValue<_, T::AuctionId, ValueQuery>;
 
+	/// Index auctions by end time.
 	#[pallet::storage]
 	#[pallet::getter(fn auction_end_time)]
-	/// Index auctions by end time.
 	pub type AuctionEndTime<T: Config> =
 		StorageDoubleMap<_, Twox64Concat, T::BlockNumber, Blake2_128Concat, T::AuctionId, (), OptionQuery>;
 
@@ -163,55 +165,55 @@ pub mod module {
 			Ok(().into())
 		}
 	}
+}
 
-	impl<T: Config> Auction<T::AccountId, T::BlockNumber> for Pallet<T> {
-		type AuctionId = T::AuctionId;
-		type Balance = T::Balance;
+impl<T: Config> Auction<T::AccountId, T::BlockNumber> for Pallet<T> {
+	type AuctionId = T::AuctionId;
+	type Balance = T::Balance;
 
-		fn auction_info(id: Self::AuctionId) -> Option<AuctionInfo<T::AccountId, Self::Balance, T::BlockNumber>> {
-			Self::auctions(id)
+	fn auction_info(id: Self::AuctionId) -> Option<AuctionInfo<T::AccountId, Self::Balance, T::BlockNumber>> {
+		Self::auctions(id)
+	}
+
+	fn update_auction(
+		id: Self::AuctionId,
+		info: AuctionInfo<T::AccountId, Self::Balance, T::BlockNumber>,
+	) -> DispatchResult {
+		let auction = Auctions::<T>::get(id).ok_or(Error::<T>::AuctionNotExist)?;
+		if let Some(old_end) = auction.end {
+			AuctionEndTime::<T>::remove(&old_end, id);
+		}
+		if let Some(new_end) = info.end {
+			AuctionEndTime::<T>::insert(&new_end, id, ());
+		}
+		Auctions::<T>::insert(id, info);
+		Ok(())
+	}
+
+	fn new_auction(
+		start: T::BlockNumber,
+		end: Option<T::BlockNumber>,
+	) -> sp_std::result::Result<Self::AuctionId, DispatchError> {
+		let auction = AuctionInfo { bid: None, start, end };
+		let auction_id =
+			<AuctionsIndex<T>>::try_mutate(|n| -> sp_std::result::Result<Self::AuctionId, DispatchError> {
+				let id = *n;
+				ensure!(id != Self::AuctionId::max_value(), Error::<T>::NoAvailableAuctionId);
+				*n += One::one();
+				Ok(id)
+			})?;
+		Auctions::<T>::insert(auction_id, auction);
+		if let Some(end_block) = end {
+			AuctionEndTime::<T>::insert(&end_block, auction_id, ());
 		}
 
-		fn update_auction(
-			id: Self::AuctionId,
-			info: AuctionInfo<T::AccountId, Self::Balance, T::BlockNumber>,
-		) -> DispatchResult {
-			let auction = Auctions::<T>::get(id).ok_or(Error::<T>::AuctionNotExist)?;
-			if let Some(old_end) = auction.end {
-				AuctionEndTime::<T>::remove(&old_end, id);
-			}
-			if let Some(new_end) = info.end {
-				AuctionEndTime::<T>::insert(&new_end, id, ());
-			}
-			Auctions::<T>::insert(id, info);
-			Ok(())
-		}
+		Ok(auction_id)
+	}
 
-		fn new_auction(
-			start: T::BlockNumber,
-			end: Option<T::BlockNumber>,
-		) -> sp_std::result::Result<Self::AuctionId, DispatchError> {
-			let auction = AuctionInfo { bid: None, start, end };
-			let auction_id =
-				<AuctionsIndex<T>>::try_mutate(|n| -> sp_std::result::Result<Self::AuctionId, DispatchError> {
-					let id = *n;
-					ensure!(id != Self::AuctionId::max_value(), Error::<T>::NoAvailableAuctionId);
-					*n += One::one();
-					Ok(id)
-				})?;
-			Auctions::<T>::insert(auction_id, auction);
-			if let Some(end_block) = end {
-				AuctionEndTime::<T>::insert(&end_block, auction_id, ());
-			}
-
-			Ok(auction_id)
-		}
-
-		fn remove_auction(id: Self::AuctionId) {
-			if let Some(auction) = Auctions::<T>::take(&id) {
-				if let Some(end_block) = auction.end {
-					AuctionEndTime::<T>::remove(end_block, id);
-				}
+	fn remove_auction(id: Self::AuctionId) {
+		if let Some(auction) = Auctions::<T>::take(&id) {
+			if let Some(end_block) = auction.end {
+				AuctionEndTime::<T>::remove(end_block, id);
 			}
 		}
 	}

--- a/auction/src/mock.rs
+++ b/auction/src/mock.rs
@@ -5,7 +5,6 @@
 use super::*;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use orml_traits::OnNewBidResult;
-use orml_traits::{AuctionHandler, Change};
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 

--- a/auction/src/tests.rs
+++ b/auction/src/tests.rs
@@ -3,9 +3,8 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{assert_noop, assert_ok, traits::OnFinalize};
+use frame_support::{assert_noop, assert_ok};
 use mock::*;
-use orml_traits::{Auction, AuctionInfo};
 
 #[test]
 fn new_auction_should_work() {

--- a/authority/src/mock.rs
+++ b/authority/src/mock.rs
@@ -6,7 +6,7 @@ use super::*;
 use codec::{Decode, Encode};
 use frame_support::{
 	parameter_types,
-	traits::{schedule::Priority, OnFinalize, OnInitialize, OriginTrait},
+	traits::{OnFinalize, OnInitialize},
 	weights::Weight,
 };
 use frame_system::{ensure_root, ensure_signed, EnsureRoot};
@@ -14,7 +14,7 @@ use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BadOrigin, IdentityLookup},
-	DispatchResult, Perbill,
+	Perbill,
 };
 
 pub use crate as authority;

--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -39,6 +39,32 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 
+use codec::Codec;
+use frame_support::{
+	pallet_prelude::*,
+	traits::{
+		Currency as PalletCurrency, ExistenceRequirement, Get, LockableCurrency as PalletLockableCurrency,
+		ReservableCurrency as PalletReservableCurrency, WithdrawReasons,
+	},
+};
+use frame_system::{ensure_root, ensure_signed, pallet_prelude::*};
+use orml_traits::{
+	account::MergeAccount,
+	arithmetic::{Signed, SimpleArithmetic},
+	BalanceStatus, BasicCurrency, BasicCurrencyExtended, BasicLockableCurrency, BasicReservableCurrency,
+	LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency,
+};
+use orml_utilities::with_transaction_result;
+use sp_runtime::{
+	traits::{CheckedSub, MaybeSerializeDeserialize, StaticLookup, Zero},
+	DispatchError, DispatchResult,
+};
+use sp_std::{
+	convert::{TryFrom, TryInto},
+	fmt::Debug,
+	marker, result,
+};
+
 mod default_weight;
 mod mock;
 mod tests;
@@ -47,31 +73,7 @@ pub use module::*;
 
 #[frame_support::pallet]
 pub mod module {
-	use codec::Codec;
-	use frame_support::{
-		pallet_prelude::*,
-		traits::{
-			Currency as PalletCurrency, ExistenceRequirement, Get, LockableCurrency as PalletLockableCurrency,
-			ReservableCurrency as PalletReservableCurrency, WithdrawReasons,
-		},
-	};
-	use frame_system::{ensure_root, ensure_signed, pallet_prelude::*};
-	use orml_traits::{
-		account::MergeAccount,
-		arithmetic::{Signed, SimpleArithmetic},
-		BalanceStatus, BasicCurrency, BasicCurrencyExtended, BasicLockableCurrency, BasicReservableCurrency,
-		LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency,
-	};
-	use orml_utilities::with_transaction_result;
-	use sp_runtime::{
-		traits::{CheckedSub, MaybeSerializeDeserialize, StaticLookup, Zero},
-		DispatchError, DispatchResult,
-	};
-	use sp_std::{
-		convert::{TryFrom, TryInto},
-		fmt::Debug,
-		marker, result,
-	};
+	use super::*;
 
 	pub trait WeightInfo {
 		fn transfer_non_native_currency() -> Weight;
@@ -81,12 +83,11 @@ pub mod module {
 		fn update_balance_native_currency_killing() -> Weight;
 	}
 
-	type BalanceOf<T> =
+	pub(crate) type BalanceOf<T> =
 		<<T as Config>::MultiCurrency as MultiCurrency<<T as frame_system::Config>::AccountId>>::Balance;
-	type CurrencyIdOf<T> =
+	pub(crate) type CurrencyIdOf<T> =
 		<<T as Config>::MultiCurrency as MultiCurrency<<T as frame_system::Config>::AccountId>>::CurrencyId;
-
-	type AmountOf<T> =
+	pub(crate) type AmountOf<T> =
 		<<T as Config>::MultiCurrency as MultiCurrencyExtended<<T as frame_system::Config>::AccountId>>::Amount;
 
 	#[pallet::config]
@@ -118,7 +119,7 @@ pub mod module {
 	}
 
 	#[pallet::event]
-	#[pallet::generate_deposit(fn deposit_event)]
+	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// Currency transfer success. [currency_id, from, to, amount]
 		Transferred(CurrencyIdOf<T>, T::AccountId, T::AccountId, BalanceOf<T>),
@@ -189,520 +190,512 @@ pub mod module {
 			Ok(().into())
 		}
 	}
+}
 
-	impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T> {
-		type CurrencyId = CurrencyIdOf<T>;
-		type Balance = BalanceOf<T>;
+impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T> {
+	type CurrencyId = CurrencyIdOf<T>;
+	type Balance = BalanceOf<T>;
 
-		fn minimum_balance(currency_id: Self::CurrencyId) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::minimum_balance()
-			} else {
-				T::MultiCurrency::minimum_balance(currency_id)
-			}
-		}
-
-		fn total_issuance(currency_id: Self::CurrencyId) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::total_issuance()
-			} else {
-				T::MultiCurrency::total_issuance(currency_id)
-			}
-		}
-
-		fn total_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::total_balance(who)
-			} else {
-				T::MultiCurrency::total_balance(currency_id, who)
-			}
-		}
-
-		fn free_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::free_balance(who)
-			} else {
-				T::MultiCurrency::free_balance(currency_id, who)
-			}
-		}
-
-		fn ensure_can_withdraw(
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::ensure_can_withdraw(who, amount)
-			} else {
-				T::MultiCurrency::ensure_can_withdraw(currency_id, who, amount)
-			}
-		}
-
-		fn transfer(
-			currency_id: Self::CurrencyId,
-			from: &T::AccountId,
-			to: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if amount.is_zero() || from == to {
-				return Ok(());
-			}
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::transfer(from, to, amount)?;
-			} else {
-				T::MultiCurrency::transfer(currency_id, from, to, amount)?;
-			}
-			Self::deposit_event(Event::Transferred(currency_id, from.clone(), to.clone(), amount));
-			Ok(())
-		}
-
-		fn deposit(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			if amount.is_zero() {
-				return Ok(());
-			}
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::deposit(who, amount)?;
-			} else {
-				T::MultiCurrency::deposit(currency_id, who, amount)?;
-			}
-			Self::deposit_event(Event::Deposited(currency_id, who.clone(), amount));
-			Ok(())
-		}
-
-		fn withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			if amount.is_zero() {
-				return Ok(());
-			}
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::withdraw(who, amount)?;
-			} else {
-				T::MultiCurrency::withdraw(currency_id, who, amount)?;
-			}
-			Self::deposit_event(Event::Withdrawn(currency_id, who.clone(), amount));
-			Ok(())
-		}
-
-		fn can_slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> bool {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::can_slash(who, amount)
-			} else {
-				T::MultiCurrency::can_slash(currency_id, who, amount)
-			}
-		}
-
-		fn slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::slash(who, amount)
-			} else {
-				T::MultiCurrency::slash(currency_id, who, amount)
-			}
+	fn minimum_balance(currency_id: Self::CurrencyId) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::minimum_balance()
+		} else {
+			T::MultiCurrency::minimum_balance(currency_id)
 		}
 	}
 
-	impl<T: Config> MultiCurrencyExtended<T::AccountId> for Pallet<T> {
-		type Amount = AmountOf<T>;
-
-		fn update_balance(
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			by_amount: Self::Amount,
-		) -> DispatchResult {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::update_balance(who, by_amount)?;
-			} else {
-				T::MultiCurrency::update_balance(currency_id, who, by_amount)?;
-			}
-			Self::deposit_event(Event::BalanceUpdated(currency_id, who.clone(), by_amount));
-			Ok(())
+	fn total_issuance(currency_id: Self::CurrencyId) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::total_issuance()
+		} else {
+			T::MultiCurrency::total_issuance(currency_id)
 		}
 	}
 
-	impl<T: Config> MultiLockableCurrency<T::AccountId> for Pallet<T> {
-		type Moment = T::BlockNumber;
-
-		fn set_lock(
-			lock_id: LockIdentifier,
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::set_lock(lock_id, who, amount)
-			} else {
-				T::MultiCurrency::set_lock(lock_id, currency_id, who, amount)
-			}
-		}
-
-		fn extend_lock(
-			lock_id: LockIdentifier,
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::extend_lock(lock_id, who, amount)
-			} else {
-				T::MultiCurrency::extend_lock(lock_id, currency_id, who, amount)
-			}
-		}
-
-		fn remove_lock(lock_id: LockIdentifier, currency_id: Self::CurrencyId, who: &T::AccountId) -> DispatchResult {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::remove_lock(lock_id, who)
-			} else {
-				T::MultiCurrency::remove_lock(lock_id, currency_id, who)
-			}
+	fn total_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::total_balance(who)
+		} else {
+			T::MultiCurrency::total_balance(currency_id, who)
 		}
 	}
 
-	impl<T: Config> MultiReservableCurrency<T::AccountId> for Pallet<T> {
-		fn can_reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> bool {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::can_reserve(who, value)
-			} else {
-				T::MultiCurrency::can_reserve(currency_id, who, value)
-			}
-		}
-
-		fn slash_reserved(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::slash_reserved(who, value)
-			} else {
-				T::MultiCurrency::slash_reserved(currency_id, who, value)
-			}
-		}
-
-		fn reserved_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::reserved_balance(who)
-			} else {
-				T::MultiCurrency::reserved_balance(currency_id, who)
-			}
-		}
-
-		fn reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> DispatchResult {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::reserve(who, value)
-			} else {
-				T::MultiCurrency::reserve(currency_id, who, value)
-			}
-		}
-
-		fn unreserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::unreserve(who, value)
-			} else {
-				T::MultiCurrency::unreserve(currency_id, who, value)
-			}
-		}
-
-		fn repatriate_reserved(
-			currency_id: Self::CurrencyId,
-			slashed: &T::AccountId,
-			beneficiary: &T::AccountId,
-			value: Self::Balance,
-			status: BalanceStatus,
-		) -> result::Result<Self::Balance, DispatchError> {
-			if currency_id == T::GetNativeCurrencyId::get() {
-				T::NativeCurrency::repatriate_reserved(slashed, beneficiary, value, status)
-			} else {
-				T::MultiCurrency::repatriate_reserved(currency_id, slashed, beneficiary, value, status)
-			}
+	fn free_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::free_balance(who)
+		} else {
+			T::MultiCurrency::free_balance(currency_id, who)
 		}
 	}
 
-	pub struct Currency<T, GetCurrencyId>(marker::PhantomData<T>, marker::PhantomData<GetCurrencyId>);
-
-	impl<T, GetCurrencyId> BasicCurrency<T::AccountId> for Currency<T, GetCurrencyId>
-	where
-		T: Config,
-		GetCurrencyId: Get<CurrencyIdOf<T>>,
-	{
-		type Balance = BalanceOf<T>;
-
-		fn minimum_balance() -> Self::Balance {
-			<Pallet<T>>::minimum_balance(GetCurrencyId::get())
-		}
-
-		fn total_issuance() -> Self::Balance {
-			<Pallet<T>>::total_issuance(GetCurrencyId::get())
-		}
-
-		fn total_balance(who: &T::AccountId) -> Self::Balance {
-			<Pallet<T>>::total_balance(GetCurrencyId::get(), who)
-		}
-
-		fn free_balance(who: &T::AccountId) -> Self::Balance {
-			<Pallet<T>>::free_balance(GetCurrencyId::get(), who)
-		}
-
-		fn ensure_can_withdraw(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			<Pallet<T>>::ensure_can_withdraw(GetCurrencyId::get(), who, amount)
-		}
-
-		fn transfer(from: &T::AccountId, to: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			<Pallet<T> as MultiCurrency<T::AccountId>>::transfer(GetCurrencyId::get(), from, to, amount)
-		}
-
-		fn deposit(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			<Pallet<T>>::deposit(GetCurrencyId::get(), who, amount)
-		}
-
-		fn withdraw(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			<Pallet<T>>::withdraw(GetCurrencyId::get(), who, amount)
-		}
-
-		fn can_slash(who: &T::AccountId, amount: Self::Balance) -> bool {
-			<Pallet<T>>::can_slash(GetCurrencyId::get(), who, amount)
-		}
-
-		fn slash(who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
-			<Pallet<T>>::slash(GetCurrencyId::get(), who, amount)
+	fn ensure_can_withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::ensure_can_withdraw(who, amount)
+		} else {
+			T::MultiCurrency::ensure_can_withdraw(currency_id, who, amount)
 		}
 	}
 
-	impl<T, GetCurrencyId> BasicCurrencyExtended<T::AccountId> for Currency<T, GetCurrencyId>
-	where
-		T: Config,
-		GetCurrencyId: Get<CurrencyIdOf<T>>,
-	{
-		type Amount = AmountOf<T>;
+	fn transfer(
+		currency_id: Self::CurrencyId,
+		from: &T::AccountId,
+		to: &T::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		if amount.is_zero() || from == to {
+			return Ok(());
+		}
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::transfer(from, to, amount)?;
+		} else {
+			T::MultiCurrency::transfer(currency_id, from, to, amount)?;
+		}
+		Self::deposit_event(Event::Transferred(currency_id, from.clone(), to.clone(), amount));
+		Ok(())
+	}
 
-		fn update_balance(who: &T::AccountId, by_amount: Self::Amount) -> DispatchResult {
-			<Pallet<T> as MultiCurrencyExtended<T::AccountId>>::update_balance(GetCurrencyId::get(), who, by_amount)
+	fn deposit(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::deposit(who, amount)?;
+		} else {
+			T::MultiCurrency::deposit(currency_id, who, amount)?;
+		}
+		Self::deposit_event(Event::Deposited(currency_id, who.clone(), amount));
+		Ok(())
+	}
+
+	fn withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::withdraw(who, amount)?;
+		} else {
+			T::MultiCurrency::withdraw(currency_id, who, amount)?;
+		}
+		Self::deposit_event(Event::Withdrawn(currency_id, who.clone(), amount));
+		Ok(())
+	}
+
+	fn can_slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> bool {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::can_slash(who, amount)
+		} else {
+			T::MultiCurrency::can_slash(currency_id, who, amount)
 		}
 	}
 
-	impl<T, GetCurrencyId> BasicLockableCurrency<T::AccountId> for Currency<T, GetCurrencyId>
-	where
-		T: Config,
-		GetCurrencyId: Get<CurrencyIdOf<T>>,
-	{
-		type Moment = T::BlockNumber;
-
-		fn set_lock(lock_id: LockIdentifier, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			<Pallet<T> as MultiLockableCurrency<T::AccountId>>::set_lock(lock_id, GetCurrencyId::get(), who, amount)
+	fn slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::slash(who, amount)
+		} else {
+			T::MultiCurrency::slash(currency_id, who, amount)
 		}
+	}
+}
 
-		fn extend_lock(lock_id: LockIdentifier, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			<Pallet<T> as MultiLockableCurrency<T::AccountId>>::extend_lock(lock_id, GetCurrencyId::get(), who, amount)
+impl<T: Config> MultiCurrencyExtended<T::AccountId> for Pallet<T> {
+	type Amount = AmountOf<T>;
+
+	fn update_balance(currency_id: Self::CurrencyId, who: &T::AccountId, by_amount: Self::Amount) -> DispatchResult {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::update_balance(who, by_amount)?;
+		} else {
+			T::MultiCurrency::update_balance(currency_id, who, by_amount)?;
 		}
+		Self::deposit_event(Event::BalanceUpdated(currency_id, who.clone(), by_amount));
+		Ok(())
+	}
+}
 
-		fn remove_lock(lock_id: LockIdentifier, who: &T::AccountId) -> DispatchResult {
-			<Pallet<T> as MultiLockableCurrency<T::AccountId>>::remove_lock(lock_id, GetCurrencyId::get(), who)
+impl<T: Config> MultiLockableCurrency<T::AccountId> for Pallet<T> {
+	type Moment = T::BlockNumber;
+
+	fn set_lock(
+		lock_id: LockIdentifier,
+		currency_id: Self::CurrencyId,
+		who: &T::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::set_lock(lock_id, who, amount)
+		} else {
+			T::MultiCurrency::set_lock(lock_id, currency_id, who, amount)
 		}
 	}
 
-	impl<T, GetCurrencyId> BasicReservableCurrency<T::AccountId> for Currency<T, GetCurrencyId>
-	where
-		T: Config,
-		GetCurrencyId: Get<CurrencyIdOf<T>>,
-	{
-		fn can_reserve(who: &T::AccountId, value: Self::Balance) -> bool {
-			<Pallet<T> as MultiReservableCurrency<T::AccountId>>::can_reserve(GetCurrencyId::get(), who, value)
-		}
-
-		fn slash_reserved(who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-			<Pallet<T> as MultiReservableCurrency<T::AccountId>>::slash_reserved(GetCurrencyId::get(), who, value)
-		}
-
-		fn reserved_balance(who: &T::AccountId) -> Self::Balance {
-			<Pallet<T> as MultiReservableCurrency<T::AccountId>>::reserved_balance(GetCurrencyId::get(), who)
-		}
-
-		fn reserve(who: &T::AccountId, value: Self::Balance) -> DispatchResult {
-			<Pallet<T> as MultiReservableCurrency<T::AccountId>>::reserve(GetCurrencyId::get(), who, value)
-		}
-
-		fn unreserve(who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-			<Pallet<T> as MultiReservableCurrency<T::AccountId>>::unreserve(GetCurrencyId::get(), who, value)
-		}
-
-		fn repatriate_reserved(
-			slashed: &T::AccountId,
-			beneficiary: &T::AccountId,
-			value: Self::Balance,
-			status: BalanceStatus,
-		) -> result::Result<Self::Balance, DispatchError> {
-			<Pallet<T> as MultiReservableCurrency<T::AccountId>>::repatriate_reserved(
-				GetCurrencyId::get(),
-				slashed,
-				beneficiary,
-				value,
-				status,
-			)
+	fn extend_lock(
+		lock_id: LockIdentifier,
+		currency_id: Self::CurrencyId,
+		who: &T::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::extend_lock(lock_id, who, amount)
+		} else {
+			T::MultiCurrency::extend_lock(lock_id, currency_id, who, amount)
 		}
 	}
 
-	pub type NativeCurrencyOf<T> = Currency<T, <T as Config>::GetNativeCurrencyId>;
-
-	/// Adapt other currency traits implementation to `BasicCurrency`.
-	pub struct BasicCurrencyAdapter<T, Currency, Amount, Moment>(marker::PhantomData<(T, Currency, Amount, Moment)>);
-
-	type PalletBalanceOf<A, Currency> = <Currency as PalletCurrency<A>>::Balance;
-
-	// Adapt `frame_support::traits::Currency`
-	impl<T, AccountId, Currency, Amount, Moment> BasicCurrency<AccountId>
-		for BasicCurrencyAdapter<T, Currency, Amount, Moment>
-	where
-		Currency: PalletCurrency<AccountId>,
-		T: Config,
-	{
-		type Balance = PalletBalanceOf<AccountId, Currency>;
-
-		fn minimum_balance() -> Self::Balance {
-			Currency::minimum_balance()
+	fn remove_lock(lock_id: LockIdentifier, currency_id: Self::CurrencyId, who: &T::AccountId) -> DispatchResult {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::remove_lock(lock_id, who)
+		} else {
+			T::MultiCurrency::remove_lock(lock_id, currency_id, who)
 		}
+	}
+}
 
-		fn total_issuance() -> Self::Balance {
-			Currency::total_issuance()
-		}
-
-		fn total_balance(who: &AccountId) -> Self::Balance {
-			Currency::total_balance(who)
-		}
-
-		fn free_balance(who: &AccountId) -> Self::Balance {
-			Currency::free_balance(who)
-		}
-
-		fn ensure_can_withdraw(who: &AccountId, amount: Self::Balance) -> DispatchResult {
-			let new_balance = Self::free_balance(who)
-				.checked_sub(&amount)
-				.ok_or(Error::<T>::BalanceTooLow)?;
-
-			Currency::ensure_can_withdraw(who, amount, WithdrawReasons::all(), new_balance)
-		}
-
-		fn transfer(from: &AccountId, to: &AccountId, amount: Self::Balance) -> DispatchResult {
-			Currency::transfer(from, to, amount, ExistenceRequirement::AllowDeath)
-		}
-
-		fn deposit(who: &AccountId, amount: Self::Balance) -> DispatchResult {
-			let _ = Currency::deposit_creating(who, amount);
-			Ok(())
-		}
-
-		fn withdraw(who: &AccountId, amount: Self::Balance) -> DispatchResult {
-			Currency::withdraw(who, amount, WithdrawReasons::all(), ExistenceRequirement::AllowDeath).map(|_| ())
-		}
-
-		fn can_slash(who: &AccountId, amount: Self::Balance) -> bool {
-			Currency::can_slash(who, amount)
-		}
-
-		fn slash(who: &AccountId, amount: Self::Balance) -> Self::Balance {
-			let (_, gap) = Currency::slash(who, amount);
-			gap
+impl<T: Config> MultiReservableCurrency<T::AccountId> for Pallet<T> {
+	fn can_reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> bool {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::can_reserve(who, value)
+		} else {
+			T::MultiCurrency::can_reserve(currency_id, who, value)
 		}
 	}
 
-	// Adapt `frame_support::traits::Currency`
-	impl<T, AccountId, Currency, Amount, Moment> BasicCurrencyExtended<AccountId>
-		for BasicCurrencyAdapter<T, Currency, Amount, Moment>
-	where
-		Amount: Signed
-			+ TryInto<PalletBalanceOf<AccountId, Currency>>
-			+ TryFrom<PalletBalanceOf<AccountId, Currency>>
-			+ SimpleArithmetic
-			+ Codec
-			+ Copy
-			+ MaybeSerializeDeserialize
-			+ Debug
-			+ Default,
-		Currency: PalletCurrency<AccountId>,
-		T: Config,
-	{
-		type Amount = Amount;
-
-		fn update_balance(who: &AccountId, by_amount: Self::Amount) -> DispatchResult {
-			let by_balance = by_amount
-				.abs()
-				.try_into()
-				.map_err(|_| Error::<T>::AmountIntoBalanceFailed)?;
-			if by_amount.is_positive() {
-				Self::deposit(who, by_balance)
-			} else {
-				Self::withdraw(who, by_balance)
-			}
+	fn slash_reserved(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::slash_reserved(who, value)
+		} else {
+			T::MultiCurrency::slash_reserved(currency_id, who, value)
 		}
 	}
 
-	// Adapt `frame_support::traits::LockableCurrency`
-	impl<T, AccountId, Currency, Amount, Moment> BasicLockableCurrency<AccountId>
-		for BasicCurrencyAdapter<T, Currency, Amount, Moment>
-	where
-		Currency: PalletLockableCurrency<AccountId>,
-		T: Config,
-	{
-		type Moment = Moment;
-
-		fn set_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) -> DispatchResult {
-			Currency::set_lock(lock_id, who, amount, WithdrawReasons::all());
-			Ok(())
-		}
-
-		fn extend_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) -> DispatchResult {
-			Currency::extend_lock(lock_id, who, amount, WithdrawReasons::all());
-			Ok(())
-		}
-
-		fn remove_lock(lock_id: LockIdentifier, who: &AccountId) -> DispatchResult {
-			Currency::remove_lock(lock_id, who);
-			Ok(())
+	fn reserved_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::reserved_balance(who)
+		} else {
+			T::MultiCurrency::reserved_balance(currency_id, who)
 		}
 	}
 
-	// Adapt `frame_support::traits::ReservableCurrency`
-	impl<T, AccountId, Currency, Amount, Moment> BasicReservableCurrency<AccountId>
-		for BasicCurrencyAdapter<T, Currency, Amount, Moment>
-	where
-		Currency: PalletReservableCurrency<AccountId>,
-		T: Config,
-	{
-		fn can_reserve(who: &AccountId, value: Self::Balance) -> bool {
-			Currency::can_reserve(who, value)
-		}
-
-		fn slash_reserved(who: &AccountId, value: Self::Balance) -> Self::Balance {
-			let (_, gap) = Currency::slash_reserved(who, value);
-			gap
-		}
-
-		fn reserved_balance(who: &AccountId) -> Self::Balance {
-			Currency::reserved_balance(who)
-		}
-
-		fn reserve(who: &AccountId, value: Self::Balance) -> DispatchResult {
-			Currency::reserve(who, value)
-		}
-
-		fn unreserve(who: &AccountId, value: Self::Balance) -> Self::Balance {
-			Currency::unreserve(who, value)
-		}
-
-		fn repatriate_reserved(
-			slashed: &AccountId,
-			beneficiary: &AccountId,
-			value: Self::Balance,
-			status: BalanceStatus,
-		) -> result::Result<Self::Balance, DispatchError> {
-			Currency::repatriate_reserved(slashed, beneficiary, value, status)
+	fn reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> DispatchResult {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::reserve(who, value)
+		} else {
+			T::MultiCurrency::reserve(currency_id, who, value)
 		}
 	}
 
-	impl<T: Config> MergeAccount<T::AccountId> for Pallet<T> {
-		fn merge_account(source: &T::AccountId, dest: &T::AccountId) -> DispatchResult {
-			with_transaction_result(|| {
-				// transfer non-native free to dest
-				T::MultiCurrency::merge_account(source, dest)?;
-
-				// unreserve all reserved currency
-				T::NativeCurrency::unreserve(source, T::NativeCurrency::reserved_balance(source));
-
-				// transfer all free to dest
-				T::NativeCurrency::transfer(source, dest, T::NativeCurrency::free_balance(source))
-			})
+	fn unreserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::unreserve(who, value)
+		} else {
+			T::MultiCurrency::unreserve(currency_id, who, value)
 		}
+	}
+
+	fn repatriate_reserved(
+		currency_id: Self::CurrencyId,
+		slashed: &T::AccountId,
+		beneficiary: &T::AccountId,
+		value: Self::Balance,
+		status: BalanceStatus,
+	) -> result::Result<Self::Balance, DispatchError> {
+		if currency_id == T::GetNativeCurrencyId::get() {
+			T::NativeCurrency::repatriate_reserved(slashed, beneficiary, value, status)
+		} else {
+			T::MultiCurrency::repatriate_reserved(currency_id, slashed, beneficiary, value, status)
+		}
+	}
+}
+
+pub struct Currency<T, GetCurrencyId>(marker::PhantomData<T>, marker::PhantomData<GetCurrencyId>);
+
+impl<T, GetCurrencyId> BasicCurrency<T::AccountId> for Currency<T, GetCurrencyId>
+where
+	T: Config,
+	GetCurrencyId: Get<CurrencyIdOf<T>>,
+{
+	type Balance = BalanceOf<T>;
+
+	fn minimum_balance() -> Self::Balance {
+		<Pallet<T>>::minimum_balance(GetCurrencyId::get())
+	}
+
+	fn total_issuance() -> Self::Balance {
+		<Pallet<T>>::total_issuance(GetCurrencyId::get())
+	}
+
+	fn total_balance(who: &T::AccountId) -> Self::Balance {
+		<Pallet<T>>::total_balance(GetCurrencyId::get(), who)
+	}
+
+	fn free_balance(who: &T::AccountId) -> Self::Balance {
+		<Pallet<T>>::free_balance(GetCurrencyId::get(), who)
+	}
+
+	fn ensure_can_withdraw(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		<Pallet<T>>::ensure_can_withdraw(GetCurrencyId::get(), who, amount)
+	}
+
+	fn transfer(from: &T::AccountId, to: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		<Pallet<T> as MultiCurrency<T::AccountId>>::transfer(GetCurrencyId::get(), from, to, amount)
+	}
+
+	fn deposit(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		<Pallet<T>>::deposit(GetCurrencyId::get(), who, amount)
+	}
+
+	fn withdraw(who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		<Pallet<T>>::withdraw(GetCurrencyId::get(), who, amount)
+	}
+
+	fn can_slash(who: &T::AccountId, amount: Self::Balance) -> bool {
+		<Pallet<T>>::can_slash(GetCurrencyId::get(), who, amount)
+	}
+
+	fn slash(who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
+		<Pallet<T>>::slash(GetCurrencyId::get(), who, amount)
+	}
+}
+
+impl<T, GetCurrencyId> BasicCurrencyExtended<T::AccountId> for Currency<T, GetCurrencyId>
+where
+	T: Config,
+	GetCurrencyId: Get<CurrencyIdOf<T>>,
+{
+	type Amount = AmountOf<T>;
+
+	fn update_balance(who: &T::AccountId, by_amount: Self::Amount) -> DispatchResult {
+		<Pallet<T> as MultiCurrencyExtended<T::AccountId>>::update_balance(GetCurrencyId::get(), who, by_amount)
+	}
+}
+
+impl<T, GetCurrencyId> BasicLockableCurrency<T::AccountId> for Currency<T, GetCurrencyId>
+where
+	T: Config,
+	GetCurrencyId: Get<CurrencyIdOf<T>>,
+{
+	type Moment = T::BlockNumber;
+
+	fn set_lock(lock_id: LockIdentifier, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		<Pallet<T> as MultiLockableCurrency<T::AccountId>>::set_lock(lock_id, GetCurrencyId::get(), who, amount)
+	}
+
+	fn extend_lock(lock_id: LockIdentifier, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		<Pallet<T> as MultiLockableCurrency<T::AccountId>>::extend_lock(lock_id, GetCurrencyId::get(), who, amount)
+	}
+
+	fn remove_lock(lock_id: LockIdentifier, who: &T::AccountId) -> DispatchResult {
+		<Pallet<T> as MultiLockableCurrency<T::AccountId>>::remove_lock(lock_id, GetCurrencyId::get(), who)
+	}
+}
+
+impl<T, GetCurrencyId> BasicReservableCurrency<T::AccountId> for Currency<T, GetCurrencyId>
+where
+	T: Config,
+	GetCurrencyId: Get<CurrencyIdOf<T>>,
+{
+	fn can_reserve(who: &T::AccountId, value: Self::Balance) -> bool {
+		<Pallet<T> as MultiReservableCurrency<T::AccountId>>::can_reserve(GetCurrencyId::get(), who, value)
+	}
+
+	fn slash_reserved(who: &T::AccountId, value: Self::Balance) -> Self::Balance {
+		<Pallet<T> as MultiReservableCurrency<T::AccountId>>::slash_reserved(GetCurrencyId::get(), who, value)
+	}
+
+	fn reserved_balance(who: &T::AccountId) -> Self::Balance {
+		<Pallet<T> as MultiReservableCurrency<T::AccountId>>::reserved_balance(GetCurrencyId::get(), who)
+	}
+
+	fn reserve(who: &T::AccountId, value: Self::Balance) -> DispatchResult {
+		<Pallet<T> as MultiReservableCurrency<T::AccountId>>::reserve(GetCurrencyId::get(), who, value)
+	}
+
+	fn unreserve(who: &T::AccountId, value: Self::Balance) -> Self::Balance {
+		<Pallet<T> as MultiReservableCurrency<T::AccountId>>::unreserve(GetCurrencyId::get(), who, value)
+	}
+
+	fn repatriate_reserved(
+		slashed: &T::AccountId,
+		beneficiary: &T::AccountId,
+		value: Self::Balance,
+		status: BalanceStatus,
+	) -> result::Result<Self::Balance, DispatchError> {
+		<Pallet<T> as MultiReservableCurrency<T::AccountId>>::repatriate_reserved(
+			GetCurrencyId::get(),
+			slashed,
+			beneficiary,
+			value,
+			status,
+		)
+	}
+}
+
+pub type NativeCurrencyOf<T> = Currency<T, <T as Config>::GetNativeCurrencyId>;
+
+/// Adapt other currency traits implementation to `BasicCurrency`.
+pub struct BasicCurrencyAdapter<T, Currency, Amount, Moment>(marker::PhantomData<(T, Currency, Amount, Moment)>);
+
+type PalletBalanceOf<A, Currency> = <Currency as PalletCurrency<A>>::Balance;
+
+// Adapt `frame_support::traits::Currency`
+impl<T, AccountId, Currency, Amount, Moment> BasicCurrency<AccountId>
+	for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+where
+	Currency: PalletCurrency<AccountId>,
+	T: Config,
+{
+	type Balance = PalletBalanceOf<AccountId, Currency>;
+
+	fn minimum_balance() -> Self::Balance {
+		Currency::minimum_balance()
+	}
+
+	fn total_issuance() -> Self::Balance {
+		Currency::total_issuance()
+	}
+
+	fn total_balance(who: &AccountId) -> Self::Balance {
+		Currency::total_balance(who)
+	}
+
+	fn free_balance(who: &AccountId) -> Self::Balance {
+		Currency::free_balance(who)
+	}
+
+	fn ensure_can_withdraw(who: &AccountId, amount: Self::Balance) -> DispatchResult {
+		let new_balance = Self::free_balance(who)
+			.checked_sub(&amount)
+			.ok_or(Error::<T>::BalanceTooLow)?;
+
+		Currency::ensure_can_withdraw(who, amount, WithdrawReasons::all(), new_balance)
+	}
+
+	fn transfer(from: &AccountId, to: &AccountId, amount: Self::Balance) -> DispatchResult {
+		Currency::transfer(from, to, amount, ExistenceRequirement::AllowDeath)
+	}
+
+	fn deposit(who: &AccountId, amount: Self::Balance) -> DispatchResult {
+		let _ = Currency::deposit_creating(who, amount);
+		Ok(())
+	}
+
+	fn withdraw(who: &AccountId, amount: Self::Balance) -> DispatchResult {
+		Currency::withdraw(who, amount, WithdrawReasons::all(), ExistenceRequirement::AllowDeath).map(|_| ())
+	}
+
+	fn can_slash(who: &AccountId, amount: Self::Balance) -> bool {
+		Currency::can_slash(who, amount)
+	}
+
+	fn slash(who: &AccountId, amount: Self::Balance) -> Self::Balance {
+		let (_, gap) = Currency::slash(who, amount);
+		gap
+	}
+}
+
+// Adapt `frame_support::traits::Currency`
+impl<T, AccountId, Currency, Amount, Moment> BasicCurrencyExtended<AccountId>
+	for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+where
+	Amount: Signed
+		+ TryInto<PalletBalanceOf<AccountId, Currency>>
+		+ TryFrom<PalletBalanceOf<AccountId, Currency>>
+		+ SimpleArithmetic
+		+ Codec
+		+ Copy
+		+ MaybeSerializeDeserialize
+		+ Debug
+		+ Default,
+	Currency: PalletCurrency<AccountId>,
+	T: Config,
+{
+	type Amount = Amount;
+
+	fn update_balance(who: &AccountId, by_amount: Self::Amount) -> DispatchResult {
+		let by_balance = by_amount
+			.abs()
+			.try_into()
+			.map_err(|_| Error::<T>::AmountIntoBalanceFailed)?;
+		if by_amount.is_positive() {
+			Self::deposit(who, by_balance)
+		} else {
+			Self::withdraw(who, by_balance)
+		}
+	}
+}
+
+// Adapt `frame_support::traits::LockableCurrency`
+impl<T, AccountId, Currency, Amount, Moment> BasicLockableCurrency<AccountId>
+	for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+where
+	Currency: PalletLockableCurrency<AccountId>,
+	T: Config,
+{
+	type Moment = Moment;
+
+	fn set_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) -> DispatchResult {
+		Currency::set_lock(lock_id, who, amount, WithdrawReasons::all());
+		Ok(())
+	}
+
+	fn extend_lock(lock_id: LockIdentifier, who: &AccountId, amount: Self::Balance) -> DispatchResult {
+		Currency::extend_lock(lock_id, who, amount, WithdrawReasons::all());
+		Ok(())
+	}
+
+	fn remove_lock(lock_id: LockIdentifier, who: &AccountId) -> DispatchResult {
+		Currency::remove_lock(lock_id, who);
+		Ok(())
+	}
+}
+
+// Adapt `frame_support::traits::ReservableCurrency`
+impl<T, AccountId, Currency, Amount, Moment> BasicReservableCurrency<AccountId>
+	for BasicCurrencyAdapter<T, Currency, Amount, Moment>
+where
+	Currency: PalletReservableCurrency<AccountId>,
+	T: Config,
+{
+	fn can_reserve(who: &AccountId, value: Self::Balance) -> bool {
+		Currency::can_reserve(who, value)
+	}
+
+	fn slash_reserved(who: &AccountId, value: Self::Balance) -> Self::Balance {
+		let (_, gap) = Currency::slash_reserved(who, value);
+		gap
+	}
+
+	fn reserved_balance(who: &AccountId) -> Self::Balance {
+		Currency::reserved_balance(who)
+	}
+
+	fn reserve(who: &AccountId, value: Self::Balance) -> DispatchResult {
+		Currency::reserve(who, value)
+	}
+
+	fn unreserve(who: &AccountId, value: Self::Balance) -> Self::Balance {
+		Currency::unreserve(who, value)
+	}
+
+	fn repatriate_reserved(
+		slashed: &AccountId,
+		beneficiary: &AccountId,
+		value: Self::Balance,
+		status: BalanceStatus,
+	) -> result::Result<Self::Balance, DispatchError> {
+		Currency::repatriate_reserved(slashed, beneficiary, value, status)
+	}
+}
+
+impl<T: Config> MergeAccount<T::AccountId> for Pallet<T> {
+	fn merge_account(source: &T::AccountId, dest: &T::AccountId) -> DispatchResult {
+		with_transaction_result(|| {
+			// transfer non-native free to dest
+			T::MultiCurrency::merge_account(source, dest)?;
+
+			// unreserve all reserved currency
+			T::NativeCurrency::unreserve(source, T::NativeCurrency::reserved_balance(source));
+
+			// transfer all free to dest
+			T::NativeCurrency::transfer(source, dest, T::NativeCurrency::free_balance(source))
+		})
 	}
 }

--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -4,8 +4,7 @@
 
 use super::*;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types, traits::GenesisBuild};
-use orml_traits::{parameter_type_with_key, LockIdentifier};
-use pallet_balances;
+use orml_traits::parameter_type_with_key;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,

--- a/currencies/src/tests.rs
+++ b/currencies/src/tests.rs
@@ -3,15 +3,8 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{assert_noop, assert_ok, traits::Currency};
-use mock::{
-	AccountId, AdaptedBasicCurrency, Currencies, ExtBuilder, NativeCurrency, Origin, PalletBalances, System, TestEvent,
-	Tokens, ALICE, BOB, EVA, ID_1, NATIVE_CURRENCY_ID, X_TOKEN_ID,
-};
-use orml_traits::{
-	BasicCurrency, BasicCurrencyExtended, BasicLockableCurrency, BasicReservableCurrency, MultiCurrency,
-	MultiCurrencyExtended, MultiLockableCurrency, MultiReservableCurrency,
-};
+use frame_support::{assert_noop, assert_ok};
+use mock::*;
 use sp_runtime::traits::BadOrigin;
 
 #[test]

--- a/gradually-update/src/mock.rs
+++ b/gradually-update/src/mock.rs
@@ -4,7 +4,6 @@
 
 use super::*;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
-use frame_system as system;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 
@@ -57,7 +56,7 @@ impl frame_system::Config for Runtime {
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 }
-pub type System = system::Module<Runtime>;
+pub type System = frame_system::Module<Runtime>;
 
 parameter_types! {
 	pub const UpdateFrequency: BlockNumber = 10;
@@ -66,7 +65,7 @@ parameter_types! {
 impl Config for Runtime {
 	type Event = TestEvent;
 	type UpdateFrequency = UpdateFrequency;
-	type DispatchOrigin = system::EnsureRoot<AccountId>;
+	type DispatchOrigin = frame_system::EnsureRoot<AccountId>;
 	type WeightInfo = ();
 }
 pub type GraduallyUpdateModule = Module<Runtime>;

--- a/gradually-update/src/tests.rs
+++ b/gradually-update/src/tests.rs
@@ -4,8 +4,8 @@
 
 use super::*;
 use codec::Encode;
-use frame_support::{assert_noop, assert_ok, traits::OnFinalize};
-use mock::{ExtBuilder, GraduallyUpdateModule, Origin, Runtime, System, TestEvent};
+use frame_support::{assert_noop, assert_ok};
+use mock::*;
 use sp_runtime::{FixedPointNumber, FixedU128, Permill};
 
 fn storage_set(key: &Vec<u8>, value: &Vec<u8>) {

--- a/nft/src/tests.rs
+++ b/nft/src/tests.rs
@@ -4,9 +4,7 @@
 
 use super::*;
 use frame_support::{assert_noop, assert_ok};
-use mock::{
-	ExtBuilder, NonFungibleTokenModule, Runtime, ALICE, BOB, CLASS_ID, CLASS_ID_NOT_EXIST, TOKEN_ID, TOKEN_ID_NOT_EXIST,
-};
+use mock::*;
 
 #[test]
 fn create_class_should_work() {

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -57,8 +57,8 @@ pub mod module {
 		fn on_finalize() -> Weight;
 	}
 
-	pub type MomentOf<T, I = ()> = <<T as Config<I>>::Time as Time>::Moment;
-	pub type TimestampedValueOf<T, I = ()> = TimestampedValue<<T as Config<I>>::OracleValue, MomentOf<T, I>>;
+	pub(crate) type MomentOf<T, I = ()> = <<T as Config<I>>::Time as Time>::Moment;
+	pub(crate) type TimestampedValueOf<T, I = ()> = TimestampedValue<<T as Config<I>>::OracleValue, MomentOf<T, I>>;
 
 	#[derive(Encode, Decode, RuntimeDebug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -103,7 +103,7 @@ pub mod module {
 	}
 
 	#[pallet::event]
-	#[pallet::generate_deposit(fn deposit_event)]
+	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// New feed data is submitted. [sender, values]
 		NewFeedData(T::AccountId, Vec<(T::OracleKey, T::OracleValue)>),
@@ -129,7 +129,8 @@ pub mod module {
 
 	/// If an oracle operator has feed a value in this block
 	#[pallet::storage]
-	type HasDispatched<T: Config<I>, I: 'static = ()> = StorageValue<_, OrderedSet<T::AccountId>, ValueQuery>;
+	pub(crate) type HasDispatched<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, OrderedSet<T::AccountId>, ValueQuery>;
 
 	// TODO: this shouldn't be required https://github.com/paritytech/substrate/issues/6041
 	/// The current members of the collective. This is stored sorted (just by

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -21,6 +21,26 @@
 #![allow(clippy::string_lit_as_bytes)]
 #![allow(clippy::unused_unit)]
 
+use codec::{Decode, Encode};
+
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
+use frame_support::{
+	ensure,
+	pallet_prelude::*,
+	traits::{ChangeMembers, Get, InitializeMembers, Time},
+	weights::{Pays, Weight},
+	Parameter,
+};
+use frame_system::{ensure_root, ensure_signed, pallet_prelude::*};
+pub use orml_traits::{CombineData, DataFeeder, DataProvider, DataProviderExtended, OnNewData};
+use orml_utilities::OrderedSet;
+use sp_runtime::{traits::Member, DispatchResult, RuntimeDebug};
+use sp_std::{prelude::*, vec};
+
+pub use crate::default_combine_data::DefaultCombineData;
+
 mod default_combine_data;
 mod default_weight;
 mod mock;
@@ -30,26 +50,7 @@ pub use module::*;
 
 #[frame_support::pallet]
 pub mod module {
-	use codec::{Decode, Encode};
-
-	use frame_support::{
-		ensure,
-		pallet_prelude::*,
-		traits::{ChangeMembers, Get, InitializeMembers, Time},
-		weights::{Pays, Weight},
-		Parameter,
-	};
-	use frame_system::{ensure_root, ensure_signed, pallet_prelude::*};
-	pub use orml_traits::{CombineData, DataFeeder, DataProvider, DataProviderExtended, OnNewData};
-	use orml_utilities::OrderedSet;
-
-	#[cfg(feature = "std")]
-	use serde::{Deserialize, Serialize};
-
-	use sp_runtime::{traits::Member, DispatchResult, RuntimeDebug};
-	use sp_std::{prelude::*, vec};
-
-	pub use crate::default_combine_data::DefaultCombineData;
+	use super::*;
 
 	pub trait WeightInfo {
 		fn feed_values(c: u32) -> Weight;
@@ -196,135 +197,135 @@ pub mod module {
 			Ok(Pays::No.into())
 		}
 	}
+}
 
-	impl<T: Config<I>, I: 'static> Pallet<T, I> {
-		pub fn read_raw_values(key: &T::OracleKey) -> Vec<TimestampedValueOf<T, I>> {
-			Self::members()
-				.0
-				.iter()
-				.chain(vec![T::RootOperatorAccountId::get()].iter())
-				.filter_map(|x| Self::raw_values(x, key))
-				.collect()
-		}
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	pub fn read_raw_values(key: &T::OracleKey) -> Vec<TimestampedValueOf<T, I>> {
+		Self::members()
+			.0
+			.iter()
+			.chain(vec![T::RootOperatorAccountId::get()].iter())
+			.filter_map(|x| Self::raw_values(x, key))
+			.collect()
+	}
 
-		/// Returns fresh combined value if has update, or latest combined
-		/// value.
-		///
-		/// Note this will update values storage if has update.
-		pub fn get(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
-			if Self::is_updated(key) {
-				<Values<T, I>>::get(key)
-			} else {
-				let timestamped = Self::combined(key)?;
-				<Values<T, I>>::insert(key, timestamped.clone());
-				IsUpdated::<T, I>::insert(key, true);
-				Some(timestamped)
-			}
-		}
-
-		/// Returns fresh combined value if has update, or latest combined
-		/// value.
-		///
-		/// This is a no-op function which would not change storage.
-		pub fn get_no_op(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
-			if Self::is_updated(key) {
-				Self::values(key)
-			} else {
-				Self::combined(key)
-			}
-		}
-
-		#[allow(clippy::complexity)]
-		pub fn get_all_values() -> Vec<(T::OracleKey, Option<TimestampedValueOf<T, I>>)> {
-			<Values<T, I>>::iter()
-				.map(|(key, _)| key)
-				.map(|key| {
-					let v = Self::get_no_op(&key);
-					(key, v)
-				})
-				.collect()
-		}
-
-		fn combined(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
-			let values = Self::read_raw_values(key);
-			T::CombineData::combine_data(key, values, Self::values(key))
-		}
-
-		fn do_feed_values(who: T::AccountId, values: Vec<(T::OracleKey, T::OracleValue)>) -> DispatchResult {
-			// ensure feeder is authorized
-			ensure!(
-				Self::members().contains(&who) || who == T::RootOperatorAccountId::get(),
-				Error::<T, I>::NoPermission
-			);
-
-			// ensure account hasn't dispatched an updated yet
-			ensure!(
-				HasDispatched::<T, I>::mutate(|set| set.insert(who.clone())),
-				Error::<T, I>::AlreadyFeeded
-			);
-
-			let now = T::Time::now();
-			for (key, value) in &values {
-				let timestamped = TimestampedValue {
-					value: value.clone(),
-					timestamp: now,
-				};
-				RawValues::<T, I>::insert(&who, &key, timestamped);
-				IsUpdated::<T, I>::remove(&key);
-
-				T::OnNewData::on_new_data(&who, &key, &value);
-			}
-			Self::deposit_event(Event::NewFeedData(who, values));
-			Ok(())
+	/// Returns fresh combined value if has update, or latest combined
+	/// value.
+	///
+	/// Note this will update values storage if has update.
+	pub fn get(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
+		if Self::is_updated(key) {
+			<Values<T, I>>::get(key)
+		} else {
+			let timestamped = Self::combined(key)?;
+			<Values<T, I>>::insert(key, timestamped.clone());
+			IsUpdated::<T, I>::insert(key, true);
+			Some(timestamped)
 		}
 	}
 
-	impl<T: Config<I>, I: 'static> InitializeMembers<T::AccountId> for Pallet<T, I> {
-		fn initialize_members(members: &[T::AccountId]) {
-			if !members.is_empty() {
-				assert!(Members::<T, I>::get().0.is_empty(), "Members are already initialized!");
-				Members::<T, I>::put(OrderedSet::from_sorted_set(members.into()));
-			}
+	/// Returns fresh combined value if has update, or latest combined
+	/// value.
+	///
+	/// This is a no-op function which would not change storage.
+	pub fn get_no_op(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
+		if Self::is_updated(key) {
+			Self::values(key)
+		} else {
+			Self::combined(key)
 		}
 	}
 
-	impl<T: Config<I>, I: 'static> ChangeMembers<T::AccountId> for Pallet<T, I> {
-		fn change_members_sorted(_incoming: &[T::AccountId], outgoing: &[T::AccountId], new: &[T::AccountId]) {
-			// remove session keys and its values
-			for removed in outgoing {
-				RawValues::<T, I>::remove_prefix(removed);
-			}
-
-			Members::<T, I>::put(OrderedSet::from_sorted_set(new.into()));
-
-			// not bothering to track which key needs recompute, just update all
-			IsUpdated::<T, I>::remove_all();
-		}
-
-		fn set_prime(_prime: Option<T::AccountId>) {
-			// nothing
-		}
+	#[allow(clippy::complexity)]
+	pub fn get_all_values() -> Vec<(T::OracleKey, Option<TimestampedValueOf<T, I>>)> {
+		<Values<T, I>>::iter()
+			.map(|(key, _)| key)
+			.map(|key| {
+				let v = Self::get_no_op(&key);
+				(key, v)
+			})
+			.collect()
 	}
 
-	impl<T: Config<I>, I: 'static> DataProvider<T::OracleKey, T::OracleValue> for Pallet<T, I> {
-		fn get(key: &T::OracleKey) -> Option<T::OracleValue> {
-			Self::get(key).map(|timestamped_value| timestamped_value.value)
-		}
-	}
-	impl<T: Config<I>, I: 'static> DataProviderExtended<T::OracleKey, TimestampedValueOf<T, I>> for Pallet<T, I> {
-		fn get_no_op(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
-			Self::get_no_op(key)
-		}
-		#[allow(clippy::complexity)]
-		fn get_all_values() -> Vec<(T::OracleKey, Option<TimestampedValueOf<T, I>>)> {
-			Self::get_all_values()
-		}
+	fn combined(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
+		let values = Self::read_raw_values(key);
+		T::CombineData::combine_data(key, values, Self::values(key))
 	}
 
-	impl<T: Config<I>, I: 'static> DataFeeder<T::OracleKey, T::OracleValue, T::AccountId> for Pallet<T, I> {
-		fn feed_value(who: T::AccountId, key: T::OracleKey, value: T::OracleValue) -> DispatchResult {
-			Self::do_feed_values(who, vec![(key, value)])?;
-			Ok(())
+	fn do_feed_values(who: T::AccountId, values: Vec<(T::OracleKey, T::OracleValue)>) -> DispatchResult {
+		// ensure feeder is authorized
+		ensure!(
+			Self::members().contains(&who) || who == T::RootOperatorAccountId::get(),
+			Error::<T, I>::NoPermission
+		);
+
+		// ensure account hasn't dispatched an updated yet
+		ensure!(
+			HasDispatched::<T, I>::mutate(|set| set.insert(who.clone())),
+			Error::<T, I>::AlreadyFeeded
+		);
+
+		let now = T::Time::now();
+		for (key, value) in &values {
+			let timestamped = TimestampedValue {
+				value: value.clone(),
+				timestamp: now,
+			};
+			RawValues::<T, I>::insert(&who, &key, timestamped);
+			IsUpdated::<T, I>::remove(&key);
+
+			T::OnNewData::on_new_data(&who, &key, &value);
 		}
+		Self::deposit_event(Event::NewFeedData(who, values));
+		Ok(())
+	}
+}
+
+impl<T: Config<I>, I: 'static> InitializeMembers<T::AccountId> for Pallet<T, I> {
+	fn initialize_members(members: &[T::AccountId]) {
+		if !members.is_empty() {
+			assert!(Members::<T, I>::get().0.is_empty(), "Members are already initialized!");
+			Members::<T, I>::put(OrderedSet::from_sorted_set(members.into()));
+		}
+	}
+}
+
+impl<T: Config<I>, I: 'static> ChangeMembers<T::AccountId> for Pallet<T, I> {
+	fn change_members_sorted(_incoming: &[T::AccountId], outgoing: &[T::AccountId], new: &[T::AccountId]) {
+		// remove session keys and its values
+		for removed in outgoing {
+			RawValues::<T, I>::remove_prefix(removed);
+		}
+
+		Members::<T, I>::put(OrderedSet::from_sorted_set(new.into()));
+
+		// not bothering to track which key needs recompute, just update all
+		IsUpdated::<T, I>::remove_all();
+	}
+
+	fn set_prime(_prime: Option<T::AccountId>) {
+		// nothing
+	}
+}
+
+impl<T: Config<I>, I: 'static> DataProvider<T::OracleKey, T::OracleValue> for Pallet<T, I> {
+	fn get(key: &T::OracleKey) -> Option<T::OracleValue> {
+		Self::get(key).map(|timestamped_value| timestamped_value.value)
+	}
+}
+impl<T: Config<I>, I: 'static> DataProviderExtended<T::OracleKey, TimestampedValueOf<T, I>> for Pallet<T, I> {
+	fn get_no_op(key: &T::OracleKey) -> Option<TimestampedValueOf<T, I>> {
+		Self::get_no_op(key)
+	}
+	#[allow(clippy::complexity)]
+	fn get_all_values() -> Vec<(T::OracleKey, Option<TimestampedValueOf<T, I>>)> {
+		Self::get_all_values()
+	}
+}
+
+impl<T: Config<I>, I: 'static> DataFeeder<T::OracleKey, T::OracleValue, T::AccountId> for Pallet<T, I> {
+	fn feed_value(who: T::AccountId, key: T::OracleKey, value: T::OracleValue) -> DispatchResult {
+		Self::do_feed_values(who, vec![(key, value)])?;
+		Ok(())
 	}
 }

--- a/oracle/src/mock.rs
+++ b/oracle/src/mock.rs
@@ -2,10 +2,7 @@
 
 use super::*;
 
-use frame_support::{
-	impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types,
-	traits::{GenesisBuild, Time},
-};
+use frame_support::{impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types, traits::GenesisBuild};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,

--- a/oracle/src/tests.rs
+++ b/oracle/src/tests.rs
@@ -1,11 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{
-	assert_noop, assert_ok,
-	traits::{ChangeMembers, OnFinalize},
-	weights::Pays,
-};
+use frame_support::{assert_noop, assert_ok, traits::OnFinalize};
 use mock::*;
 
 #[test]

--- a/oracle/src/tests.rs
+++ b/oracle/src/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{assert_noop, assert_ok, traits::OnFinalize};
+use frame_support::{assert_noop, assert_ok};
 use mock::*;
 
 #[test]

--- a/rewards/src/lib.rs
+++ b/rewards/src/lib.rs
@@ -5,38 +5,40 @@ mod default_weight;
 mod mock;
 mod tests;
 
+use codec::{FullCodec, HasCompact};
+use frame_support::pallet_prelude::*;
+use orml_traits::RewardHandler;
+use sp_runtime::{
+	traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize, Member, Saturating, Zero},
+	FixedPointNumber, FixedPointOperand, FixedU128, RuntimeDebug,
+};
+use sp_std::{
+	cmp::{Eq, PartialEq},
+	fmt::Debug,
+};
+
+/// The Reward Pool Info.
+#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, Default)]
+pub struct PoolInfo<Share: HasCompact, Balance: HasCompact> {
+	/// Total shares amount
+	#[codec(compact)]
+	pub total_shares: Share,
+	/// Total rewards amount
+	#[codec(compact)]
+	pub total_rewards: Balance,
+	/// Total withdrawn rewards amount
+	#[codec(compact)]
+	pub total_withdrawn_rewards: Balance,
+}
+
 pub use module::*;
 
 #[frame_support::pallet]
 pub mod module {
-	use codec::{FullCodec, HasCompact};
-	use frame_support::pallet_prelude::*;
-	use orml_traits::RewardHandler;
-	use sp_runtime::{
-		traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize, Member, Saturating, Zero},
-		FixedPointNumber, FixedPointOperand, FixedU128, RuntimeDebug,
-	};
-	use sp_std::{
-		cmp::{Eq, PartialEq},
-		fmt::Debug,
-	};
+	use super::*;
 
 	pub trait WeightInfo {
 		fn on_initialize(c: u32) -> Weight;
-	}
-
-	/// The Reward Pool Info.
-	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, Default)]
-	pub struct PoolInfo<Share: HasCompact, Balance: HasCompact> {
-		/// Total shares amount
-		#[codec(compact)]
-		pub total_shares: Share,
-		/// Total rewards amount
-		#[codec(compact)]
-		pub total_rewards: Balance,
-		/// Total withdrawn rewards amount
-		#[codec(compact)]
-		pub total_withdrawn_rewards: Balance,
 	}
 
 	#[pallet::config]
@@ -77,15 +79,15 @@ pub mod module {
 		type WeightInfo: WeightInfo;
 	}
 
+	/// Stores reward pool info.
 	#[pallet::storage]
 	#[pallet::getter(fn pools)]
-	/// Stores reward pool info.
 	pub type Pools<T: Config> = StorageMap<_, Twox64Concat, T::PoolId, PoolInfo<T::Share, T::Balance>, ValueQuery>;
 
-	#[pallet::storage]
-	#[pallet::getter(fn share_and_withdrawn_reward)]
 	/// Record share amount and withdrawn reward amount for specific `AccountId`
 	/// under `PoolId`.
+	#[pallet::storage]
+	#[pallet::getter(fn share_and_withdrawn_reward)]
 	pub type ShareAndWithdrawnReward<T: Config> =
 		StorageDoubleMap<_, Twox64Concat, T::PoolId, Twox64Concat, T::AccountId, (T::Share, T::Balance), ValueQuery>;
 
@@ -110,101 +112,99 @@ pub mod module {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}
+}
 
-	impl<T: Config> Pallet<T> {
-		pub fn add_share(who: &T::AccountId, pool: T::PoolId, add_amount: T::Share) {
-			if add_amount.is_zero() {
-				return;
-			}
-
-			Pools::<T>::mutate(pool, |pool_info| {
-				let proportion =
-					FixedU128::checked_from_rational(add_amount, pool_info.total_shares).unwrap_or_default();
-				let reward_inflation = proportion.saturating_mul_int(pool_info.total_rewards);
-
-				pool_info.total_shares = pool_info.total_shares.saturating_add(add_amount);
-				pool_info.total_rewards = pool_info.total_rewards.saturating_add(reward_inflation);
-				pool_info.total_withdrawn_rewards = pool_info.total_withdrawn_rewards.saturating_add(reward_inflation);
-
-				ShareAndWithdrawnReward::<T>::mutate(pool, who, |(share, withdrawn_rewards)| {
-					*share = share.saturating_add(add_amount);
-					*withdrawn_rewards = withdrawn_rewards.saturating_add(reward_inflation);
-				});
-			});
+impl<T: Config> Pallet<T> {
+	pub fn add_share(who: &T::AccountId, pool: T::PoolId, add_amount: T::Share) {
+		if add_amount.is_zero() {
+			return;
 		}
 
-		pub fn remove_share(who: &T::AccountId, pool: T::PoolId, remove_amount: T::Share) {
+		Pools::<T>::mutate(pool, |pool_info| {
+			let proportion = FixedU128::checked_from_rational(add_amount, pool_info.total_shares).unwrap_or_default();
+			let reward_inflation = proportion.saturating_mul_int(pool_info.total_rewards);
+
+			pool_info.total_shares = pool_info.total_shares.saturating_add(add_amount);
+			pool_info.total_rewards = pool_info.total_rewards.saturating_add(reward_inflation);
+			pool_info.total_withdrawn_rewards = pool_info.total_withdrawn_rewards.saturating_add(reward_inflation);
+
+			ShareAndWithdrawnReward::<T>::mutate(pool, who, |(share, withdrawn_rewards)| {
+				*share = share.saturating_add(add_amount);
+				*withdrawn_rewards = withdrawn_rewards.saturating_add(reward_inflation);
+			});
+		});
+	}
+
+	pub fn remove_share(who: &T::AccountId, pool: T::PoolId, remove_amount: T::Share) {
+		if remove_amount.is_zero() {
+			return;
+		}
+
+		// claim rewards firstly
+		Self::claim_rewards(who, pool);
+
+		ShareAndWithdrawnReward::<T>::mutate(pool, who, |(share, withdrawn_rewards)| {
+			let remove_amount = remove_amount.min(*share);
+
 			if remove_amount.is_zero() {
 				return;
 			}
 
-			// claim rewards firstly
-			Self::claim_rewards(who, pool);
+			Pools::<T>::mutate(pool, |pool_info| {
+				let proportion = FixedU128::checked_from_rational(remove_amount, *share).unwrap_or_default();
+				let withdrawn_rewards_to_remove = proportion.saturating_mul_int(*withdrawn_rewards);
 
-			ShareAndWithdrawnReward::<T>::mutate(pool, who, |(share, withdrawn_rewards)| {
-				let remove_amount = remove_amount.min(*share);
+				pool_info.total_shares = pool_info.total_shares.saturating_sub(remove_amount);
+				pool_info.total_rewards = pool_info.total_rewards.saturating_sub(withdrawn_rewards_to_remove);
+				pool_info.total_withdrawn_rewards = pool_info
+					.total_withdrawn_rewards
+					.saturating_sub(withdrawn_rewards_to_remove);
 
-				if remove_amount.is_zero() {
-					return;
-				}
-
-				Pools::<T>::mutate(pool, |pool_info| {
-					let proportion = FixedU128::checked_from_rational(remove_amount, *share).unwrap_or_default();
-					let withdrawn_rewards_to_remove = proportion.saturating_mul_int(*withdrawn_rewards);
-
-					pool_info.total_shares = pool_info.total_shares.saturating_sub(remove_amount);
-					pool_info.total_rewards = pool_info.total_rewards.saturating_sub(withdrawn_rewards_to_remove);
-					pool_info.total_withdrawn_rewards = pool_info
-						.total_withdrawn_rewards
-						.saturating_sub(withdrawn_rewards_to_remove);
-
-					*withdrawn_rewards = withdrawn_rewards.saturating_sub(withdrawn_rewards_to_remove);
-				});
-
-				*share = share.saturating_sub(remove_amount);
+				*withdrawn_rewards = withdrawn_rewards.saturating_sub(withdrawn_rewards_to_remove);
 			});
+
+			*share = share.saturating_sub(remove_amount);
+		});
+	}
+
+	pub fn set_share(who: &T::AccountId, pool: T::PoolId, new_share: T::Share) {
+		let (share, _) = Self::share_and_withdrawn_reward(pool, who);
+
+		if new_share > share {
+			Self::add_share(who, pool, new_share.saturating_sub(share));
+		} else {
+			Self::remove_share(who, pool, share.saturating_sub(new_share));
 		}
+	}
 
-		pub fn set_share(who: &T::AccountId, pool: T::PoolId, new_share: T::Share) {
-			let (share, _) = Self::share_and_withdrawn_reward(pool, who);
-
-			if new_share > share {
-				Self::add_share(who, pool, new_share.saturating_sub(share));
-			} else {
-				Self::remove_share(who, pool, share.saturating_sub(new_share));
+	pub fn claim_rewards(who: &T::AccountId, pool: T::PoolId) {
+		ShareAndWithdrawnReward::<T>::mutate(pool, who, |(share, withdrawn_rewards)| {
+			if share.is_zero() {
+				return;
 			}
-		}
 
-		pub fn claim_rewards(who: &T::AccountId, pool: T::PoolId) {
-			ShareAndWithdrawnReward::<T>::mutate(pool, who, |(share, withdrawn_rewards)| {
-				if share.is_zero() {
+			Pools::<T>::mutate(pool, |pool_info| {
+				let proportion = FixedU128::checked_from_rational(*share, pool_info.total_shares).unwrap_or_default();
+				let reward_to_withdraw = proportion
+					.saturating_mul_int(pool_info.total_rewards)
+					.saturating_sub(*withdrawn_rewards)
+					.min(
+						pool_info
+							.total_rewards
+							.saturating_sub(pool_info.total_withdrawn_rewards),
+					);
+
+				if reward_to_withdraw.is_zero() {
 					return;
 				}
 
-				Pools::<T>::mutate(pool, |pool_info| {
-					let proportion =
-						FixedU128::checked_from_rational(*share, pool_info.total_shares).unwrap_or_default();
-					let reward_to_withdraw = proportion
-						.saturating_mul_int(pool_info.total_rewards)
-						.saturating_sub(*withdrawn_rewards)
-						.min(
-							pool_info
-								.total_rewards
-								.saturating_sub(pool_info.total_withdrawn_rewards),
-						);
+				pool_info.total_withdrawn_rewards =
+					pool_info.total_withdrawn_rewards.saturating_add(reward_to_withdraw);
+				*withdrawn_rewards = withdrawn_rewards.saturating_add(reward_to_withdraw);
 
-					if reward_to_withdraw.is_zero() {
-						return;
-					}
-
-					pool_info.total_withdrawn_rewards =
-						pool_info.total_withdrawn_rewards.saturating_add(reward_to_withdraw);
-					*withdrawn_rewards = withdrawn_rewards.saturating_add(reward_to_withdraw);
-
-					// pay reward to `who`
-					T::Handler::payout(who, pool, reward_to_withdraw);
-				});
+				// pay reward to `who`
+				T::Handler::payout(who, pool, reward_to_withdraw);
 			});
-		}
+		});
 	}
 }

--- a/rewards/src/mock.rs
+++ b/rewards/src/mock.rs
@@ -4,7 +4,6 @@
 
 use super::*;
 use frame_support::{impl_outer_origin, parameter_types};
-use orml_traits::RewardHandler;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 use sp_std::cell::RefCell;

--- a/rewards/src/tests.rs
+++ b/rewards/src/tests.rs
@@ -3,7 +3,6 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::traits::OnInitialize;
 use mock::*;
 
 #[test]

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -37,120 +37,122 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 
+pub use crate::imbalances::{NegativeImbalance, PositiveImbalance};
+
+use frame_support::{
+	ensure,
+	pallet_prelude::*,
+	traits::{
+		BalanceStatus as Status, Currency as PalletCurrency, ExistenceRequirement, Get, Imbalance,
+		LockableCurrency as PalletLockableCurrency, ReservableCurrency as PalletReservableCurrency, SignedImbalance,
+		WithdrawReasons,
+	},
+	transactional,
+};
+use frame_system::{ensure_signed, pallet_prelude::*};
+use orml_traits::{
+	account::MergeAccount,
+	arithmetic::{self, Signed},
+	BalanceStatus, GetByKey, LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency,
+	MultiReservableCurrency, OnDust,
+};
+use sp_runtime::{
+	traits::{
+		AccountIdConversion, AtLeast32BitUnsigned, Bounded, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Member,
+		Saturating, StaticLookup, Zero,
+	},
+	DispatchError, DispatchResult, ModuleId, RuntimeDebug,
+};
+use sp_std::{
+	convert::{Infallible, TryFrom, TryInto},
+	marker,
+	prelude::*,
+	vec::Vec,
+};
+
 mod default_weight;
 mod imbalances;
 mod mock;
 mod tests;
 
+pub struct TransferDust<T, GetAccountId>(marker::PhantomData<(T, GetAccountId)>);
+impl<T, GetAccountId> OnDust<T::AccountId, T::CurrencyId, T::Balance> for TransferDust<T, GetAccountId>
+where
+	T: Config,
+	GetAccountId: Get<T::AccountId>,
+{
+	fn on_dust(who: &T::AccountId, currency_id: T::CurrencyId, amount: T::Balance) {
+		// transfer the dust to treasury account, ignore the result,
+		// if failed will leave some dust which still could be recycled.
+		let _ = <Pallet<T> as MultiCurrency<T::AccountId>>::transfer(currency_id, who, &GetAccountId::get(), amount);
+	}
+}
+
+pub struct BurnDust<T>(marker::PhantomData<T>);
+impl<T: Config> OnDust<T::AccountId, T::CurrencyId, T::Balance> for BurnDust<T> {
+	fn on_dust(who: &T::AccountId, currency_id: T::CurrencyId, amount: T::Balance) {
+		// burn the dust, ignore the result,
+		// if failed will leave some dust which still could be recycled.
+		let _ = Pallet::<T>::withdraw(currency_id, who, amount);
+	}
+}
+
+/// A single lock on a balance. There can be many of these on an account and
+/// they "overlap", so the same balance is frozen by multiple locks.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub struct BalanceLock<Balance> {
+	/// An identifier for this lock. Only one lock may be in existence for
+	/// each identifier.
+	pub id: LockIdentifier,
+	/// The amount which the free balance may not drop below when this lock
+	/// is in effect.
+	pub amount: Balance,
+}
+
+/// balance information for an account.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+pub struct AccountData<Balance> {
+	/// Non-reserved part of the balance. There may still be restrictions on
+	/// this, but it is the total pool what may in principle be transferred,
+	/// reserved.
+	///
+	/// This is the only balance that matters in terms of most operations on
+	/// tokens.
+	pub free: Balance,
+	/// Balance which is reserved and may not be used at all.
+	///
+	/// This can still get slashed, but gets slashed last of all.
+	///
+	/// This balance is a 'reserve' balance that other subsystems use in
+	/// order to set aside tokens that are still 'owned' by the account
+	/// holder, but which are suspendable.
+	pub reserved: Balance,
+	/// The amount that `free` may not drop below when withdrawing.
+	pub frozen: Balance,
+}
+
+impl<Balance: Saturating + Copy + Ord> AccountData<Balance> {
+	/// The amount that this account's free balance may not be reduced
+	/// beyond.
+	pub(crate) fn frozen(&self) -> Balance {
+		self.frozen
+	}
+	/// The total balance in this account including any that is reserved and
+	/// ignoring any frozen.
+	fn total(&self) -> Balance {
+		self.free.saturating_add(self.reserved)
+	}
+}
+
 pub use module::*;
 
 #[frame_support::pallet]
 pub mod module {
-	pub use crate::imbalances::{NegativeImbalance, PositiveImbalance};
-	use frame_support::{
-		ensure,
-		pallet_prelude::*,
-		traits::{
-			BalanceStatus as Status, Currency as PalletCurrency, ExistenceRequirement, Get, Imbalance,
-			LockableCurrency as PalletLockableCurrency, ReservableCurrency as PalletReservableCurrency,
-			SignedImbalance, WithdrawReasons,
-		},
-		transactional,
-	};
-	use frame_system::{ensure_signed, pallet_prelude::*};
-	use orml_traits::{
-		account::MergeAccount,
-		arithmetic::{self, Signed},
-		BalanceStatus, GetByKey, LockIdentifier, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency,
-		MultiReservableCurrency, OnDust,
-	};
-	use sp_runtime::{
-		traits::{
-			AccountIdConversion, AtLeast32BitUnsigned, Bounded, CheckedAdd, CheckedSub, MaybeSerializeDeserialize,
-			Member, Saturating, StaticLookup, Zero,
-		},
-		DispatchError, DispatchResult, ModuleId, RuntimeDebug,
-	};
-	use sp_std::{
-		convert::{Infallible, TryFrom, TryInto},
-		marker,
-		prelude::*,
-		vec::Vec,
-	};
+	use super::*;
 
 	pub trait WeightInfo {
 		fn transfer() -> Weight;
 		fn transfer_all() -> Weight;
-	}
-
-	pub struct TransferDust<T, GetAccountId>(marker::PhantomData<(T, GetAccountId)>);
-	impl<T, GetAccountId> OnDust<T::AccountId, T::CurrencyId, T::Balance> for TransferDust<T, GetAccountId>
-	where
-		T: Config,
-		GetAccountId: Get<T::AccountId>,
-	{
-		fn on_dust(who: &T::AccountId, currency_id: T::CurrencyId, amount: T::Balance) {
-			// transfer the dust to treasury account, ignore the result,
-			// if failed will leave some dust which still could be recycled.
-			let _ =
-				<Pallet<T> as MultiCurrency<T::AccountId>>::transfer(currency_id, who, &GetAccountId::get(), amount);
-		}
-	}
-
-	pub struct BurnDust<T>(marker::PhantomData<T>);
-	impl<T: Config> OnDust<T::AccountId, T::CurrencyId, T::Balance> for BurnDust<T> {
-		fn on_dust(who: &T::AccountId, currency_id: T::CurrencyId, amount: T::Balance) {
-			// burn the dust, ignore the result,
-			// if failed will leave some dust which still could be recycled.
-			let _ = Pallet::<T>::withdraw(currency_id, who, amount);
-		}
-	}
-
-	/// A single lock on a balance. There can be many of these on an account and
-	/// they "overlap", so the same balance is frozen by multiple locks.
-	#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
-	pub struct BalanceLock<Balance> {
-		/// An identifier for this lock. Only one lock may be in existence for
-		/// each identifier.
-		pub id: LockIdentifier,
-		/// The amount which the free balance may not drop below when this lock
-		/// is in effect.
-		pub amount: Balance,
-	}
-
-	/// balance information for an account.
-	#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
-	pub struct AccountData<Balance> {
-		/// Non-reserved part of the balance. There may still be restrictions on
-		/// this, but it is the total pool what may in principle be transferred,
-		/// reserved.
-		///
-		/// This is the only balance that matters in terms of most operations on
-		/// tokens.
-		pub free: Balance,
-		/// Balance which is reserved and may not be used at all.
-		///
-		/// This can still get slashed, but gets slashed last of all.
-		///
-		/// This balance is a 'reserve' balance that other subsystems use in
-		/// order to set aside tokens that are still 'owned' by the account
-		/// holder, but which are suspendable.
-		pub reserved: Balance,
-		/// The amount that `free` may not drop below when withdrawing.
-		pub frozen: Balance,
-	}
-
-	impl<Balance: Saturating + Copy + Ord> AccountData<Balance> {
-		/// The amount that this account's free balance may not be reduced
-		/// beyond.
-		pub(crate) fn frozen(&self) -> Balance {
-			self.frozen
-		}
-		/// The total balance in this account including any that is reserved and
-		/// ignoring any frozen.
-		fn total(&self) -> Balance {
-			self.free.saturating_add(self.reserved)
-		}
 	}
 
 	#[pallet::config]
@@ -201,7 +203,7 @@ pub mod module {
 	}
 
 	#[pallet::event]
-	#[pallet::generate_deposit(fn deposit_event)]
+	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// Token transfer success. \[currency_id, from, to, amount\]
 		Transferred(T::CurrencyId, T::AccountId, T::AccountId, T::Balance),
@@ -211,15 +213,15 @@ pub mod module {
 		DustLost(T::AccountId, T::CurrencyId, T::Balance),
 	}
 
+	/// The total issuance of a token type.
 	#[pallet::storage]
 	#[pallet::getter(fn total_issuance)]
-	/// The total issuance of a token type.
 	pub type TotalIssuance<T: Config> = StorageMap<_, Twox64Concat, T::CurrencyId, T::Balance, ValueQuery>;
 
-	#[pallet::storage]
-	#[pallet::getter(fn locks)]
 	/// Any liquidity locks of a token type under an account.
 	/// NOTE: Should only be accessed when setting, changing and freeing a lock.
+	#[pallet::storage]
+	#[pallet::getter(fn locks)]
 	pub type Locks<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
@@ -230,14 +232,14 @@ pub mod module {
 		ValueQuery,
 	>;
 
-	#[pallet::storage]
-	#[pallet::getter(fn accounts)]
 	/// The balance of a token type under an account.
 	///
 	/// NOTE: If the total is ever zero, decrease account ref account.
 	///
 	/// NOTE: This is only used in the case that this module is used to store
 	/// balances.
+	#[pallet::storage]
+	#[pallet::getter(fn accounts)]
 	pub type Accounts<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
@@ -341,723 +343,715 @@ pub mod module {
 			Ok(().into())
 		}
 	}
+}
 
-	impl<T: Config> Pallet<T> {
-		/// Check whether account_id is a module account
-		pub(crate) fn is_module_account_id(account_id: &T::AccountId) -> bool {
-			ModuleId::try_from_account(account_id).is_some()
-		}
+impl<T: Config> Pallet<T> {
+	/// Check whether account_id is a module account
+	pub(crate) fn is_module_account_id(account_id: &T::AccountId) -> bool {
+		ModuleId::try_from_account(account_id).is_some()
+	}
 
-		pub(crate) fn try_mutate_account<R, E>(
-			who: &T::AccountId,
-			currency_id: T::CurrencyId,
-			f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> sp_std::result::Result<R, E>,
-		) -> sp_std::result::Result<R, E> {
-			Accounts::<T>::try_mutate_exists(who, currency_id, |maybe_account| {
-				let existed = maybe_account.is_some();
-				let mut account = maybe_account.take().unwrap_or_default();
-				f(&mut account, existed).map(move |result| {
-					let mut handle_dust: Option<T::Balance> = None;
-					let total = account.total();
-					*maybe_account = if total.is_zero() {
-						None
-					} else {
-						// if non_zero total is below existential deposit and the account is not a
-						// module account, should handle the dust.
-						if total < T::ExistentialDeposits::get(&currency_id) && !Self::is_module_account_id(who) {
-							handle_dust = Some(total);
-						}
-						Some(account)
-					};
-
-					(existed, maybe_account.is_some(), handle_dust, result)
-				})
-			})
-			.map(|(existed, exists, handle_dust, result)| {
-				if existed && !exists {
-					// If existed before, decrease account provider.
-					// Ignore the result, because if it failed means that these’s remain consumers,
-					// and the account storage in frame_system shouldn't be repeaded.
-					let _ = frame_system::Module::<T>::dec_providers(who);
-				} else if !existed && exists {
-					// if new, increase account provider
-					frame_system::Module::<T>::inc_providers(who);
-				}
-
-				if let Some(dust_amount) = handle_dust {
-					// `OnDust` maybe get/set storage `Accounts` of `who`, trigger handler here
-					// to avoid some unexpected errors.
-					T::OnDust::on_dust(who, currency_id, dust_amount);
-					Self::deposit_event(Event::DustLost(who.clone(), currency_id, dust_amount));
-				}
-
-				result
-			})
-		}
-
-		pub(crate) fn mutate_account<R>(
-			who: &T::AccountId,
-			currency_id: T::CurrencyId,
-			f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> R,
-		) -> R {
-			Self::try_mutate_account(who, currency_id, |account, existed| -> Result<R, Infallible> {
-				Ok(f(account, existed))
-			})
-			.expect("Error is infallible; qed")
-		}
-
-		/// Set free balance of `who` to a new value.
-		///
-		/// Note this will not maintain total issuance, and the caller is
-		/// expected to do it.
-		pub(crate) fn set_free_balance(currency_id: T::CurrencyId, who: &T::AccountId, amount: T::Balance) {
-			Self::mutate_account(who, currency_id, |account, _| {
-				account.free = amount;
-			});
-		}
-
-		/// Set reserved balance of `who` to a new value.
-		///
-		/// Note this will not maintain total issuance, and the caller is
-		/// expected to do it.
-		pub(crate) fn set_reserved_balance(currency_id: T::CurrencyId, who: &T::AccountId, amount: T::Balance) {
-			Self::mutate_account(who, currency_id, |account, _| {
-				account.reserved = amount;
-			});
-		}
-
-		/// Update the account entry for `who` under `currency_id`, given the
-		/// locks.
-		pub(crate) fn update_locks(currency_id: T::CurrencyId, who: &T::AccountId, locks: &[BalanceLock<T::Balance>]) {
-			// update account data
-			Self::mutate_account(who, currency_id, |account, _| {
-				account.frozen = Zero::zero();
-				for lock in locks.iter() {
-					account.frozen = account.frozen.max(lock.amount);
-				}
-			});
-
-			// update locks
-			let existed = <Locks<T>>::contains_key(who, currency_id);
-			if locks.is_empty() {
-				<Locks<T>>::remove(who, currency_id);
-				if existed {
-					// decrease account ref count when destruct lock
-					frame_system::Module::<T>::dec_consumers(who);
-				}
-			} else {
-				<Locks<T>>::insert(who, currency_id, locks);
-				if !existed {
-					// increase account ref count when initialize lock
-					if frame_system::Module::<T>::inc_consumers(who).is_err() {
-						// No providers for the locks. This is impossible under normal circumstances
-						// since the funds that are under the lock will themselves be stored in the
-						// account and therefore will need a reference.
-						frame_support::debug::warn!(
-							"Warning: Attempt to introduce lock consumer reference, yet no providers. \
-							This is unexpected but should be safe."
-						);
+	pub(crate) fn try_mutate_account<R, E>(
+		who: &T::AccountId,
+		currency_id: T::CurrencyId,
+		f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> sp_std::result::Result<R, E>,
+	) -> sp_std::result::Result<R, E> {
+		Accounts::<T>::try_mutate_exists(who, currency_id, |maybe_account| {
+			let existed = maybe_account.is_some();
+			let mut account = maybe_account.take().unwrap_or_default();
+			f(&mut account, existed).map(move |result| {
+				let mut handle_dust: Option<T::Balance> = None;
+				let total = account.total();
+				*maybe_account = if total.is_zero() {
+					None
+				} else {
+					// if non_zero total is below existential deposit and the account is not a
+					// module account, should handle the dust.
+					if total < T::ExistentialDeposits::get(&currency_id) && !Self::is_module_account_id(who) {
+						handle_dust = Some(total);
 					}
-				}
-			}
-		}
-	}
-
-	impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T> {
-		type CurrencyId = T::CurrencyId;
-		type Balance = T::Balance;
-
-		fn minimum_balance(currency_id: Self::CurrencyId) -> Self::Balance {
-			T::ExistentialDeposits::get(&currency_id)
-		}
-
-		fn total_issuance(currency_id: Self::CurrencyId) -> Self::Balance {
-			<TotalIssuance<T>>::get(currency_id)
-		}
-
-		fn total_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
-			Self::accounts(who, currency_id).total()
-		}
-
-		fn free_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
-			Self::accounts(who, currency_id).free
-		}
-
-		// Ensure that an account can withdraw from their free balance given any
-		// existing withdrawal restrictions like locks and vesting balance.
-		// Is a no-op if amount to be withdrawn is zero.
-		fn ensure_can_withdraw(
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if amount.is_zero() {
-				return Ok(());
-			}
-
-			let new_balance = Self::free_balance(currency_id, who)
-				.checked_sub(&amount)
-				.ok_or(Error::<T>::BalanceTooLow)?;
-			ensure!(
-				new_balance >= Self::accounts(who, currency_id).frozen(),
-				Error::<T>::LiquidityRestrictions
-			);
-			Ok(())
-		}
-
-		/// Transfer some free balance from `from` to `to`.
-		/// Is a no-op if value to be transferred is zero or the `from` is the
-		/// same as `to`.
-		fn transfer(
-			currency_id: Self::CurrencyId,
-			from: &T::AccountId,
-			to: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if amount.is_zero() || from == to {
-				return Ok(());
-			}
-			Self::ensure_can_withdraw(currency_id, from, amount)?;
-
-			let from_balance = Self::free_balance(currency_id, from);
-			let to_balance = Self::free_balance(currency_id, to)
-				.checked_add(&amount)
-				.ok_or(Error::<T>::BalanceOverflow)?;
-			// Cannot underflow because ensure_can_withdraw check
-			Self::set_free_balance(currency_id, from, from_balance - amount);
-			Self::set_free_balance(currency_id, to, to_balance);
-
-			Ok(())
-		}
-
-		/// Deposit some `amount` into the free balance of account `who`.
-		///
-		/// Is a no-op if the `amount` to be deposited is zero.
-		fn deposit(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			if amount.is_zero() {
-				return Ok(());
-			}
-
-			TotalIssuance::<T>::try_mutate(currency_id, |total_issuance| -> DispatchResult {
-				*total_issuance = total_issuance
-					.checked_add(&amount)
-					.ok_or(Error::<T>::TotalIssuanceOverflow)?;
-
-				Self::set_free_balance(currency_id, who, Self::free_balance(currency_id, who) + amount);
-
-				Ok(())
-			})
-		}
-
-		fn withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-			if amount.is_zero() {
-				return Ok(());
-			}
-			Self::ensure_can_withdraw(currency_id, who, amount)?;
-
-			// Cannot underflow because ensure_can_withdraw check
-			<TotalIssuance<T>>::mutate(currency_id, |v| *v -= amount);
-			Self::set_free_balance(currency_id, who, Self::free_balance(currency_id, who) - amount);
-
-			Ok(())
-		}
-
-		// Check if `value` amount of free balance can be slashed from `who`.
-		fn can_slash(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> bool {
-			if value.is_zero() {
-				return true;
-			}
-			Self::free_balance(currency_id, who) >= value
-		}
-
-		/// Is a no-op if `value` to be slashed is zero.
-		///
-		/// NOTE: `slash()` prefers free balance, but assumes that reserve
-		/// balance can be drawn from in extreme circumstances. `can_slash()`
-		/// should be used prior to `slash()` to avoid having to draw from
-		/// reserved funds, however we err on the side of punishment if things
-		/// are inconsistent or `can_slash` wasn't used appropriately.
-		fn slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
-			if amount.is_zero() {
-				return amount;
-			}
-
-			let account = Self::accounts(who, currency_id);
-			let free_slashed_amount = account.free.min(amount);
-			// Cannot underflow becuase free_slashed_amount can never be greater than amount
-			let mut remaining_slash = amount - free_slashed_amount;
-
-			// slash free balance
-			if !free_slashed_amount.is_zero() {
-				// Cannot underflow becuase free_slashed_amount can never be greater than
-				// account.free
-				Self::set_free_balance(currency_id, who, account.free - free_slashed_amount);
-			}
-
-			// slash reserved balance
-			if !remaining_slash.is_zero() {
-				let reserved_slashed_amount = account.reserved.min(remaining_slash);
-				// Cannot underflow due to above line
-				remaining_slash -= reserved_slashed_amount;
-				Self::set_reserved_balance(currency_id, who, account.reserved - reserved_slashed_amount);
-			}
-
-			// Cannot underflow because the slashed value cannot be greater than total
-			// issuance
-			<TotalIssuance<T>>::mutate(currency_id, |v| *v -= amount - remaining_slash);
-			remaining_slash
-		}
-	}
-
-	impl<T: Config> MultiCurrencyExtended<T::AccountId> for Pallet<T> {
-		type Amount = T::Amount;
-
-		fn update_balance(
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			by_amount: Self::Amount,
-		) -> DispatchResult {
-			if by_amount.is_zero() {
-				return Ok(());
-			}
-
-			// Ensure this doesn't overflow. There isn't any traits that exposes
-			// `saturating_abs` so we need to do it manually.
-			let by_amount_abs = if by_amount == Self::Amount::min_value() {
-				Self::Amount::max_value()
-			} else {
-				by_amount.abs()
-			};
-
-			let by_balance =
-				TryInto::<Self::Balance>::try_into(by_amount_abs).map_err(|_| Error::<T>::AmountIntoBalanceFailed)?;
-			if by_amount.is_positive() {
-				Self::deposit(currency_id, who, by_balance)
-			} else {
-				Self::withdraw(currency_id, who, by_balance).map(|_| ())
-			}
-		}
-	}
-
-	impl<T: Config> MultiLockableCurrency<T::AccountId> for Pallet<T> {
-		type Moment = T::BlockNumber;
-
-		// Set a lock on the balance of `who` under `currency_id`.
-		// Is a no-op if lock amount is zero.
-		fn set_lock(
-			lock_id: LockIdentifier,
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if amount.is_zero() {
-				return Ok(());
-			}
-			let mut new_lock = Some(BalanceLock { id: lock_id, amount });
-			let mut locks = Self::locks(who, currency_id)
-				.into_iter()
-				.filter_map(|lock| {
-					if lock.id == lock_id {
-						new_lock.take()
-					} else {
-						Some(lock)
-					}
-				})
-				.collect::<Vec<_>>();
-			if let Some(lock) = new_lock {
-				locks.push(lock)
-			}
-			Self::update_locks(currency_id, who, &locks[..]);
-			Ok(())
-		}
-
-		// Extend a lock on the balance of `who` under `currency_id`.
-		// Is a no-op if lock amount is zero
-		fn extend_lock(
-			lock_id: LockIdentifier,
-			currency_id: Self::CurrencyId,
-			who: &T::AccountId,
-			amount: Self::Balance,
-		) -> DispatchResult {
-			if amount.is_zero() {
-				return Ok(());
-			}
-			let mut new_lock = Some(BalanceLock { id: lock_id, amount });
-			let mut locks = Self::locks(who, currency_id)
-				.into_iter()
-				.filter_map(|lock| {
-					if lock.id == lock_id {
-						new_lock.take().map(|nl| BalanceLock {
-							id: lock.id,
-							amount: lock.amount.max(nl.amount),
-						})
-					} else {
-						Some(lock)
-					}
-				})
-				.collect::<Vec<_>>();
-			if let Some(lock) = new_lock {
-				locks.push(lock)
-			}
-			Self::update_locks(currency_id, who, &locks[..]);
-			Ok(())
-		}
-
-		fn remove_lock(lock_id: LockIdentifier, currency_id: Self::CurrencyId, who: &T::AccountId) -> DispatchResult {
-			let mut locks = Self::locks(who, currency_id);
-			locks.retain(|lock| lock.id != lock_id);
-			Self::update_locks(currency_id, who, &locks[..]);
-			Ok(())
-		}
-	}
-
-	impl<T: Config> MultiReservableCurrency<T::AccountId> for Pallet<T> {
-		/// Check if `who` can reserve `value` from their free balance.
-		///
-		/// Always `true` if value to be reserved is zero.
-		fn can_reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> bool {
-			if value.is_zero() {
-				return true;
-			}
-			Self::ensure_can_withdraw(currency_id, who, value).is_ok()
-		}
-
-		/// Slash from reserved balance, returning any amount that was unable to
-		/// be slashed.
-		///
-		/// Is a no-op if the value to be slashed is zero.
-		fn slash_reserved(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-			if value.is_zero() {
-				return value;
-			}
-
-			let reserved_balance = Self::reserved_balance(currency_id, who);
-			let actual = reserved_balance.min(value);
-			Self::set_reserved_balance(currency_id, who, reserved_balance - actual);
-			<TotalIssuance<T>>::mutate(currency_id, |v| *v -= actual);
-			value - actual
-		}
-
-		fn reserved_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
-			Self::accounts(who, currency_id).reserved
-		}
-
-		/// Move `value` from the free balance from `who` to their reserved
-		/// balance.
-		///
-		/// Is a no-op if value to be reserved is zero.
-		fn reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> DispatchResult {
-			if value.is_zero() {
-				return Ok(());
-			}
-			Self::ensure_can_withdraw(currency_id, who, value)?;
-
-			let account = Self::accounts(who, currency_id);
-			Self::set_free_balance(currency_id, who, account.free - value);
-			// Cannot overflow becuase total issuance is using the same balance type and
-			// this doesn't increase total issuance
-			Self::set_reserved_balance(currency_id, who, account.reserved + value);
-			Ok(())
-		}
-
-		/// Unreserve some funds, returning any amount that was unable to be
-		/// unreserved.
-		///
-		/// Is a no-op if the value to be unreserved is zero.
-		fn unreserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-			if value.is_zero() {
-				return value;
-			}
-
-			let account = Self::accounts(who, currency_id);
-			let actual = account.reserved.min(value);
-			Self::set_reserved_balance(currency_id, who, account.reserved - actual);
-			Self::set_free_balance(currency_id, who, account.free + actual);
-
-			value - actual
-		}
-
-		/// Move the reserved balance of one account into the balance of
-		/// another, according to `status`.
-		///
-		/// Is a no-op if:
-		/// - the value to be moved is zero; or
-		/// - the `slashed` id equal to `beneficiary` and the `status` is
-		///   `Reserved`.
-		fn repatriate_reserved(
-			currency_id: Self::CurrencyId,
-			slashed: &T::AccountId,
-			beneficiary: &T::AccountId,
-			value: Self::Balance,
-			status: BalanceStatus,
-		) -> sp_std::result::Result<Self::Balance, DispatchError> {
-			if value.is_zero() {
-				return Ok(value);
-			}
-
-			if slashed == beneficiary {
-				return match status {
-					BalanceStatus::Free => Ok(Self::unreserve(currency_id, slashed, value)),
-					BalanceStatus::Reserved => Ok(value.saturating_sub(Self::reserved_balance(currency_id, slashed))),
+					Some(account)
 				};
-			}
 
-			let from_account = Self::accounts(slashed, currency_id);
-			let to_account = Self::accounts(beneficiary, currency_id);
-			let actual = from_account.reserved.min(value);
-			match status {
-				BalanceStatus::Free => {
-					Self::set_free_balance(currency_id, beneficiary, to_account.free + actual);
-				}
-				BalanceStatus::Reserved => {
-					Self::set_reserved_balance(currency_id, beneficiary, to_account.reserved + actual);
-				}
-			}
-			Self::set_reserved_balance(currency_id, slashed, from_account.reserved - actual);
-			Ok(value - actual)
-		}
-	}
-
-	pub struct CurrencyAdapter<T, GetCurrencyId>(marker::PhantomData<(T, GetCurrencyId)>);
-
-	impl<T, GetCurrencyId> PalletCurrency<T::AccountId> for CurrencyAdapter<T, GetCurrencyId>
-	where
-		T: Config,
-		GetCurrencyId: Get<T::CurrencyId>,
-	{
-		type Balance = T::Balance;
-		type PositiveImbalance = PositiveImbalance<T, GetCurrencyId>;
-		type NegativeImbalance = NegativeImbalance<T, GetCurrencyId>;
-
-		fn total_balance(who: &T::AccountId) -> Self::Balance {
-			Pallet::<T>::total_balance(GetCurrencyId::get(), who)
-		}
-
-		fn can_slash(who: &T::AccountId, value: Self::Balance) -> bool {
-			Pallet::<T>::can_slash(GetCurrencyId::get(), who, value)
-		}
-
-		fn total_issuance() -> Self::Balance {
-			Pallet::<T>::total_issuance(GetCurrencyId::get())
-		}
-
-		fn minimum_balance() -> Self::Balance {
-			Pallet::<T>::minimum_balance(GetCurrencyId::get())
-		}
-
-		fn burn(mut amount: Self::Balance) -> Self::PositiveImbalance {
-			if amount.is_zero() {
-				return PositiveImbalance::zero();
-			}
-			<TotalIssuance<T>>::mutate(GetCurrencyId::get(), |issued| {
-				*issued = issued.checked_sub(&amount).unwrap_or_else(|| {
-					amount = *issued;
-					Zero::zero()
-				});
-			});
-			PositiveImbalance::new(amount)
-		}
-
-		fn issue(mut amount: Self::Balance) -> Self::NegativeImbalance {
-			if amount.is_zero() {
-				return NegativeImbalance::zero();
-			}
-			<TotalIssuance<T>>::mutate(GetCurrencyId::get(), |issued| {
-				*issued = issued.checked_add(&amount).unwrap_or_else(|| {
-					amount = Self::Balance::max_value() - *issued;
-					Self::Balance::max_value()
-				})
-			});
-			NegativeImbalance::new(amount)
-		}
-
-		fn free_balance(who: &T::AccountId) -> Self::Balance {
-			Pallet::<T>::free_balance(GetCurrencyId::get(), who)
-		}
-
-		fn ensure_can_withdraw(
-			who: &T::AccountId,
-			amount: Self::Balance,
-			_reasons: WithdrawReasons,
-			_new_balance: Self::Balance,
-		) -> DispatchResult {
-			Pallet::<T>::ensure_can_withdraw(GetCurrencyId::get(), who, amount)
-		}
-
-		fn transfer(
-			source: &T::AccountId,
-			dest: &T::AccountId,
-			value: Self::Balance,
-			_existence_requirement: ExistenceRequirement,
-		) -> DispatchResult {
-			<Pallet<T> as MultiCurrency<T::AccountId>>::transfer(GetCurrencyId::get(), &source, &dest, value)
-		}
-
-		fn slash(who: &T::AccountId, value: Self::Balance) -> (Self::NegativeImbalance, Self::Balance) {
-			if value.is_zero() {
-				return (Self::NegativeImbalance::zero(), value);
-			}
-
-			let currency_id = GetCurrencyId::get();
-			let account = Pallet::<T>::accounts(who, currency_id);
-			let free_slashed_amount = account.free.min(value);
-			let mut remaining_slash = value - free_slashed_amount;
-
-			// slash free balance
-			if !free_slashed_amount.is_zero() {
-				Pallet::<T>::set_free_balance(currency_id, who, account.free - free_slashed_amount);
-			}
-
-			// slash reserved balance
-			if !remaining_slash.is_zero() {
-				let reserved_slashed_amount = account.reserved.min(remaining_slash);
-				remaining_slash -= reserved_slashed_amount;
-				Pallet::<T>::set_reserved_balance(currency_id, who, account.reserved - reserved_slashed_amount);
-				(
-					Self::NegativeImbalance::new(free_slashed_amount + reserved_slashed_amount),
-					remaining_slash,
-				)
-			} else {
-				(Self::NegativeImbalance::new(value), remaining_slash)
-			}
-		}
-
-		fn deposit_into_existing(
-			who: &T::AccountId,
-			value: Self::Balance,
-		) -> sp_std::result::Result<Self::PositiveImbalance, DispatchError> {
-			if value.is_zero() {
-				return Ok(Self::PositiveImbalance::zero());
-			}
-			let currency_id = GetCurrencyId::get();
-			let new_total = Pallet::<T>::free_balance(currency_id, who)
-				.checked_add(&value)
-				.ok_or(Error::<T>::TotalIssuanceOverflow)?;
-			Pallet::<T>::set_free_balance(currency_id, who, new_total);
-
-			Ok(Self::PositiveImbalance::new(value))
-		}
-
-		fn deposit_creating(who: &T::AccountId, value: Self::Balance) -> Self::PositiveImbalance {
-			Self::deposit_into_existing(who, value).unwrap_or_else(|_| Self::PositiveImbalance::zero())
-		}
-
-		fn withdraw(
-			who: &T::AccountId,
-			value: Self::Balance,
-			_reasons: WithdrawReasons,
-			_liveness: ExistenceRequirement,
-		) -> sp_std::result::Result<Self::NegativeImbalance, DispatchError> {
-			if value.is_zero() {
-				return Ok(Self::NegativeImbalance::zero());
-			}
-			let currency_id = GetCurrencyId::get();
-			Pallet::<T>::ensure_can_withdraw(currency_id, who, value)?;
-			Pallet::<T>::set_free_balance(currency_id, who, Pallet::<T>::free_balance(currency_id, who) - value);
-
-			Ok(Self::NegativeImbalance::new(value))
-		}
-
-		fn make_free_balance_be(
-			who: &T::AccountId,
-			value: Self::Balance,
-		) -> SignedImbalance<Self::Balance, Self::PositiveImbalance> {
-			let currency_id = GetCurrencyId::get();
-			Pallet::<T>::try_mutate_account(
-				who,
-				currency_id,
-				|account, existed| -> Result<SignedImbalance<Self::Balance, Self::PositiveImbalance>, ()> {
-					// If we're attempting to set an existing account to less than ED, then
-					// bypass the entire operation. It's a no-op if you follow it through, but
-					// since this is an instance where we might account for a negative imbalance
-					// (in the dust cleaner of set_account) before we account for its actual
-					// equal and opposite cause (returned as an Imbalance), then in the
-					// instance that there's no other accounts on the system at all, we might
-					// underflow the issuance and our arithmetic will be off.
-					let ed = T::ExistentialDeposits::get(&currency_id);
-					ensure!(value.saturating_add(account.reserved) >= ed || existed, ());
-
-					let imbalance = if account.free <= value {
-						SignedImbalance::Positive(PositiveImbalance::new(value - account.free))
-					} else {
-						SignedImbalance::Negative(NegativeImbalance::new(account.free - value))
-					};
-					account.free = value;
-					Ok(imbalance)
-				},
-			)
-			.unwrap_or_else(|_| SignedImbalance::Positive(Self::PositiveImbalance::zero()))
-		}
-	}
-
-	impl<T, GetCurrencyId> PalletReservableCurrency<T::AccountId> for CurrencyAdapter<T, GetCurrencyId>
-	where
-		T: Config,
-		GetCurrencyId: Get<T::CurrencyId>,
-	{
-		fn can_reserve(who: &T::AccountId, value: Self::Balance) -> bool {
-			Pallet::<T>::can_reserve(GetCurrencyId::get(), who, value)
-		}
-
-		fn slash_reserved(who: &T::AccountId, value: Self::Balance) -> (Self::NegativeImbalance, Self::Balance) {
-			let actual = Pallet::<T>::slash_reserved(GetCurrencyId::get(), who, value);
-			(Self::NegativeImbalance::zero(), actual)
-		}
-
-		fn reserved_balance(who: &T::AccountId) -> Self::Balance {
-			Pallet::<T>::reserved_balance(GetCurrencyId::get(), who)
-		}
-
-		fn reserve(who: &T::AccountId, value: Self::Balance) -> DispatchResult {
-			Pallet::<T>::reserve(GetCurrencyId::get(), who, value)
-		}
-
-		fn unreserve(who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-			Pallet::<T>::unreserve(GetCurrencyId::get(), who, value)
-		}
-
-		fn repatriate_reserved(
-			slashed: &T::AccountId,
-			beneficiary: &T::AccountId,
-			value: Self::Balance,
-			status: Status,
-		) -> sp_std::result::Result<Self::Balance, DispatchError> {
-			Pallet::<T>::repatriate_reserved(GetCurrencyId::get(), slashed, beneficiary, value, status)
-		}
-	}
-
-	impl<T, GetCurrencyId> PalletLockableCurrency<T::AccountId> for CurrencyAdapter<T, GetCurrencyId>
-	where
-		T: Config,
-		GetCurrencyId: Get<T::CurrencyId>,
-	{
-		type Moment = T::BlockNumber;
-		type MaxLocks = ();
-
-		fn set_lock(id: LockIdentifier, who: &T::AccountId, amount: Self::Balance, _reasons: WithdrawReasons) {
-			let _ = Pallet::<T>::set_lock(id, GetCurrencyId::get(), who, amount);
-		}
-
-		fn extend_lock(id: LockIdentifier, who: &T::AccountId, amount: Self::Balance, _reasons: WithdrawReasons) {
-			let _ = Pallet::<T>::extend_lock(id, GetCurrencyId::get(), who, amount);
-		}
-
-		fn remove_lock(id: LockIdentifier, who: &T::AccountId) {
-			let _ = Pallet::<T>::remove_lock(id, GetCurrencyId::get(), who);
-		}
-	}
-
-	impl<T: Config> MergeAccount<T::AccountId> for Pallet<T> {
-		#[transactional]
-		fn merge_account(source: &T::AccountId, dest: &T::AccountId) -> DispatchResult {
-			Accounts::<T>::iter_prefix(source).try_for_each(|(currency_id, account_data)| -> DispatchResult {
-				// ensure the account has no active reserved of non-native token
-				ensure!(account_data.reserved.is_zero(), Error::<T>::StillHasActiveReserved);
-
-				// transfer all free to recipient
-				<Self as MultiCurrency<T::AccountId>>::transfer(currency_id, source, dest, account_data.free)?;
-				Ok(())
+				(existed, maybe_account.is_some(), handle_dust, result)
 			})
+		})
+		.map(|(existed, exists, handle_dust, result)| {
+			if existed && !exists {
+				// If existed before, decrease account provider.
+				// Ignore the result, because if it failed means that these’s remain consumers,
+				// and the account storage in frame_system shouldn't be repeaded.
+				let _ = frame_system::Module::<T>::dec_providers(who);
+			} else if !existed && exists {
+				// if new, increase account provider
+				frame_system::Module::<T>::inc_providers(who);
+			}
+
+			if let Some(dust_amount) = handle_dust {
+				// `OnDust` maybe get/set storage `Accounts` of `who`, trigger handler here
+				// to avoid some unexpected errors.
+				T::OnDust::on_dust(who, currency_id, dust_amount);
+				Self::deposit_event(Event::DustLost(who.clone(), currency_id, dust_amount));
+			}
+
+			result
+		})
+	}
+
+	pub(crate) fn mutate_account<R>(
+		who: &T::AccountId,
+		currency_id: T::CurrencyId,
+		f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> R,
+	) -> R {
+		Self::try_mutate_account(who, currency_id, |account, existed| -> Result<R, Infallible> {
+			Ok(f(account, existed))
+		})
+		.expect("Error is infallible; qed")
+	}
+
+	/// Set free balance of `who` to a new value.
+	///
+	/// Note this will not maintain total issuance, and the caller is
+	/// expected to do it.
+	pub(crate) fn set_free_balance(currency_id: T::CurrencyId, who: &T::AccountId, amount: T::Balance) {
+		Self::mutate_account(who, currency_id, |account, _| {
+			account.free = amount;
+		});
+	}
+
+	/// Set reserved balance of `who` to a new value.
+	///
+	/// Note this will not maintain total issuance, and the caller is
+	/// expected to do it.
+	pub(crate) fn set_reserved_balance(currency_id: T::CurrencyId, who: &T::AccountId, amount: T::Balance) {
+		Self::mutate_account(who, currency_id, |account, _| {
+			account.reserved = amount;
+		});
+	}
+
+	/// Update the account entry for `who` under `currency_id`, given the
+	/// locks.
+	pub(crate) fn update_locks(currency_id: T::CurrencyId, who: &T::AccountId, locks: &[BalanceLock<T::Balance>]) {
+		// update account data
+		Self::mutate_account(who, currency_id, |account, _| {
+			account.frozen = Zero::zero();
+			for lock in locks.iter() {
+				account.frozen = account.frozen.max(lock.amount);
+			}
+		});
+
+		// update locks
+		let existed = <Locks<T>>::contains_key(who, currency_id);
+		if locks.is_empty() {
+			<Locks<T>>::remove(who, currency_id);
+			if existed {
+				// decrease account ref count when destruct lock
+				frame_system::Module::<T>::dec_consumers(who);
+			}
+		} else {
+			<Locks<T>>::insert(who, currency_id, locks);
+			if !existed {
+				// increase account ref count when initialize lock
+				if frame_system::Module::<T>::inc_consumers(who).is_err() {
+					// No providers for the locks. This is impossible under normal circumstances
+					// since the funds that are under the lock will themselves be stored in the
+					// account and therefore will need a reference.
+					frame_support::debug::warn!(
+						"Warning: Attempt to introduce lock consumer reference, yet no providers. \
+						This is unexpected but should be safe."
+					);
+				}
+			}
 		}
+	}
+}
+
+impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T> {
+	type CurrencyId = T::CurrencyId;
+	type Balance = T::Balance;
+
+	fn minimum_balance(currency_id: Self::CurrencyId) -> Self::Balance {
+		T::ExistentialDeposits::get(&currency_id)
+	}
+
+	fn total_issuance(currency_id: Self::CurrencyId) -> Self::Balance {
+		<TotalIssuance<T>>::get(currency_id)
+	}
+
+	fn total_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+		Self::accounts(who, currency_id).total()
+	}
+
+	fn free_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+		Self::accounts(who, currency_id).free
+	}
+
+	// Ensure that an account can withdraw from their free balance given any
+	// existing withdrawal restrictions like locks and vesting balance.
+	// Is a no-op if amount to be withdrawn is zero.
+	fn ensure_can_withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+
+		let new_balance = Self::free_balance(currency_id, who)
+			.checked_sub(&amount)
+			.ok_or(Error::<T>::BalanceTooLow)?;
+		ensure!(
+			new_balance >= Self::accounts(who, currency_id).frozen(),
+			Error::<T>::LiquidityRestrictions
+		);
+		Ok(())
+	}
+
+	/// Transfer some free balance from `from` to `to`.
+	/// Is a no-op if value to be transferred is zero or the `from` is the
+	/// same as `to`.
+	fn transfer(
+		currency_id: Self::CurrencyId,
+		from: &T::AccountId,
+		to: &T::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		if amount.is_zero() || from == to {
+			return Ok(());
+		}
+		Self::ensure_can_withdraw(currency_id, from, amount)?;
+
+		let from_balance = Self::free_balance(currency_id, from);
+		let to_balance = Self::free_balance(currency_id, to)
+			.checked_add(&amount)
+			.ok_or(Error::<T>::BalanceOverflow)?;
+		// Cannot underflow because ensure_can_withdraw check
+		Self::set_free_balance(currency_id, from, from_balance - amount);
+		Self::set_free_balance(currency_id, to, to_balance);
+
+		Ok(())
+	}
+
+	/// Deposit some `amount` into the free balance of account `who`.
+	///
+	/// Is a no-op if the `amount` to be deposited is zero.
+	fn deposit(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+
+		TotalIssuance::<T>::try_mutate(currency_id, |total_issuance| -> DispatchResult {
+			*total_issuance = total_issuance
+				.checked_add(&amount)
+				.ok_or(Error::<T>::TotalIssuanceOverflow)?;
+
+			Self::set_free_balance(currency_id, who, Self::free_balance(currency_id, who) + amount);
+
+			Ok(())
+		})
+	}
+
+	fn withdraw(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+		Self::ensure_can_withdraw(currency_id, who, amount)?;
+
+		// Cannot underflow because ensure_can_withdraw check
+		<TotalIssuance<T>>::mutate(currency_id, |v| *v -= amount);
+		Self::set_free_balance(currency_id, who, Self::free_balance(currency_id, who) - amount);
+
+		Ok(())
+	}
+
+	// Check if `value` amount of free balance can be slashed from `who`.
+	fn can_slash(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> bool {
+		if value.is_zero() {
+			return true;
+		}
+		Self::free_balance(currency_id, who) >= value
+	}
+
+	/// Is a no-op if `value` to be slashed is zero.
+	///
+	/// NOTE: `slash()` prefers free balance, but assumes that reserve
+	/// balance can be drawn from in extreme circumstances. `can_slash()`
+	/// should be used prior to `slash()` to avoid having to draw from
+	/// reserved funds, however we err on the side of punishment if things
+	/// are inconsistent or `can_slash` wasn't used appropriately.
+	fn slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
+		if amount.is_zero() {
+			return amount;
+		}
+
+		let account = Self::accounts(who, currency_id);
+		let free_slashed_amount = account.free.min(amount);
+		// Cannot underflow becuase free_slashed_amount can never be greater than amount
+		let mut remaining_slash = amount - free_slashed_amount;
+
+		// slash free balance
+		if !free_slashed_amount.is_zero() {
+			// Cannot underflow becuase free_slashed_amount can never be greater than
+			// account.free
+			Self::set_free_balance(currency_id, who, account.free - free_slashed_amount);
+		}
+
+		// slash reserved balance
+		if !remaining_slash.is_zero() {
+			let reserved_slashed_amount = account.reserved.min(remaining_slash);
+			// Cannot underflow due to above line
+			remaining_slash -= reserved_slashed_amount;
+			Self::set_reserved_balance(currency_id, who, account.reserved - reserved_slashed_amount);
+		}
+
+		// Cannot underflow because the slashed value cannot be greater than total
+		// issuance
+		<TotalIssuance<T>>::mutate(currency_id, |v| *v -= amount - remaining_slash);
+		remaining_slash
+	}
+}
+
+impl<T: Config> MultiCurrencyExtended<T::AccountId> for Pallet<T> {
+	type Amount = T::Amount;
+
+	fn update_balance(currency_id: Self::CurrencyId, who: &T::AccountId, by_amount: Self::Amount) -> DispatchResult {
+		if by_amount.is_zero() {
+			return Ok(());
+		}
+
+		// Ensure this doesn't overflow. There isn't any traits that exposes
+		// `saturating_abs` so we need to do it manually.
+		let by_amount_abs = if by_amount == Self::Amount::min_value() {
+			Self::Amount::max_value()
+		} else {
+			by_amount.abs()
+		};
+
+		let by_balance =
+			TryInto::<Self::Balance>::try_into(by_amount_abs).map_err(|_| Error::<T>::AmountIntoBalanceFailed)?;
+		if by_amount.is_positive() {
+			Self::deposit(currency_id, who, by_balance)
+		} else {
+			Self::withdraw(currency_id, who, by_balance).map(|_| ())
+		}
+	}
+}
+
+impl<T: Config> MultiLockableCurrency<T::AccountId> for Pallet<T> {
+	type Moment = T::BlockNumber;
+
+	// Set a lock on the balance of `who` under `currency_id`.
+	// Is a no-op if lock amount is zero.
+	fn set_lock(
+		lock_id: LockIdentifier,
+		currency_id: Self::CurrencyId,
+		who: &T::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+		let mut new_lock = Some(BalanceLock { id: lock_id, amount });
+		let mut locks = Self::locks(who, currency_id)
+			.into_iter()
+			.filter_map(|lock| {
+				if lock.id == lock_id {
+					new_lock.take()
+				} else {
+					Some(lock)
+				}
+			})
+			.collect::<Vec<_>>();
+		if let Some(lock) = new_lock {
+			locks.push(lock)
+		}
+		Self::update_locks(currency_id, who, &locks[..]);
+		Ok(())
+	}
+
+	// Extend a lock on the balance of `who` under `currency_id`.
+	// Is a no-op if lock amount is zero
+	fn extend_lock(
+		lock_id: LockIdentifier,
+		currency_id: Self::CurrencyId,
+		who: &T::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+		let mut new_lock = Some(BalanceLock { id: lock_id, amount });
+		let mut locks = Self::locks(who, currency_id)
+			.into_iter()
+			.filter_map(|lock| {
+				if lock.id == lock_id {
+					new_lock.take().map(|nl| BalanceLock {
+						id: lock.id,
+						amount: lock.amount.max(nl.amount),
+					})
+				} else {
+					Some(lock)
+				}
+			})
+			.collect::<Vec<_>>();
+		if let Some(lock) = new_lock {
+			locks.push(lock)
+		}
+		Self::update_locks(currency_id, who, &locks[..]);
+		Ok(())
+	}
+
+	fn remove_lock(lock_id: LockIdentifier, currency_id: Self::CurrencyId, who: &T::AccountId) -> DispatchResult {
+		let mut locks = Self::locks(who, currency_id);
+		locks.retain(|lock| lock.id != lock_id);
+		Self::update_locks(currency_id, who, &locks[..]);
+		Ok(())
+	}
+}
+
+impl<T: Config> MultiReservableCurrency<T::AccountId> for Pallet<T> {
+	/// Check if `who` can reserve `value` from their free balance.
+	///
+	/// Always `true` if value to be reserved is zero.
+	fn can_reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> bool {
+		if value.is_zero() {
+			return true;
+		}
+		Self::ensure_can_withdraw(currency_id, who, value).is_ok()
+	}
+
+	/// Slash from reserved balance, returning any amount that was unable to
+	/// be slashed.
+	///
+	/// Is a no-op if the value to be slashed is zero.
+	fn slash_reserved(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
+		if value.is_zero() {
+			return value;
+		}
+
+		let reserved_balance = Self::reserved_balance(currency_id, who);
+		let actual = reserved_balance.min(value);
+		Self::set_reserved_balance(currency_id, who, reserved_balance - actual);
+		<TotalIssuance<T>>::mutate(currency_id, |v| *v -= actual);
+		value - actual
+	}
+
+	fn reserved_balance(currency_id: Self::CurrencyId, who: &T::AccountId) -> Self::Balance {
+		Self::accounts(who, currency_id).reserved
+	}
+
+	/// Move `value` from the free balance from `who` to their reserved
+	/// balance.
+	///
+	/// Is a no-op if value to be reserved is zero.
+	fn reserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> DispatchResult {
+		if value.is_zero() {
+			return Ok(());
+		}
+		Self::ensure_can_withdraw(currency_id, who, value)?;
+
+		let account = Self::accounts(who, currency_id);
+		Self::set_free_balance(currency_id, who, account.free - value);
+		// Cannot overflow becuase total issuance is using the same balance type and
+		// this doesn't increase total issuance
+		Self::set_reserved_balance(currency_id, who, account.reserved + value);
+		Ok(())
+	}
+
+	/// Unreserve some funds, returning any amount that was unable to be
+	/// unreserved.
+	///
+	/// Is a no-op if the value to be unreserved is zero.
+	fn unreserve(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
+		if value.is_zero() {
+			return value;
+		}
+
+		let account = Self::accounts(who, currency_id);
+		let actual = account.reserved.min(value);
+		Self::set_reserved_balance(currency_id, who, account.reserved - actual);
+		Self::set_free_balance(currency_id, who, account.free + actual);
+
+		value - actual
+	}
+
+	/// Move the reserved balance of one account into the balance of
+	/// another, according to `status`.
+	///
+	/// Is a no-op if:
+	/// - the value to be moved is zero; or
+	/// - the `slashed` id equal to `beneficiary` and the `status` is
+	///   `Reserved`.
+	fn repatriate_reserved(
+		currency_id: Self::CurrencyId,
+		slashed: &T::AccountId,
+		beneficiary: &T::AccountId,
+		value: Self::Balance,
+		status: BalanceStatus,
+	) -> sp_std::result::Result<Self::Balance, DispatchError> {
+		if value.is_zero() {
+			return Ok(value);
+		}
+
+		if slashed == beneficiary {
+			return match status {
+				BalanceStatus::Free => Ok(Self::unreserve(currency_id, slashed, value)),
+				BalanceStatus::Reserved => Ok(value.saturating_sub(Self::reserved_balance(currency_id, slashed))),
+			};
+		}
+
+		let from_account = Self::accounts(slashed, currency_id);
+		let to_account = Self::accounts(beneficiary, currency_id);
+		let actual = from_account.reserved.min(value);
+		match status {
+			BalanceStatus::Free => {
+				Self::set_free_balance(currency_id, beneficiary, to_account.free + actual);
+			}
+			BalanceStatus::Reserved => {
+				Self::set_reserved_balance(currency_id, beneficiary, to_account.reserved + actual);
+			}
+		}
+		Self::set_reserved_balance(currency_id, slashed, from_account.reserved - actual);
+		Ok(value - actual)
+	}
+}
+
+pub struct CurrencyAdapter<T, GetCurrencyId>(marker::PhantomData<(T, GetCurrencyId)>);
+
+impl<T, GetCurrencyId> PalletCurrency<T::AccountId> for CurrencyAdapter<T, GetCurrencyId>
+where
+	T: Config,
+	GetCurrencyId: Get<T::CurrencyId>,
+{
+	type Balance = T::Balance;
+	type PositiveImbalance = PositiveImbalance<T, GetCurrencyId>;
+	type NegativeImbalance = NegativeImbalance<T, GetCurrencyId>;
+
+	fn total_balance(who: &T::AccountId) -> Self::Balance {
+		Pallet::<T>::total_balance(GetCurrencyId::get(), who)
+	}
+
+	fn can_slash(who: &T::AccountId, value: Self::Balance) -> bool {
+		Pallet::<T>::can_slash(GetCurrencyId::get(), who, value)
+	}
+
+	fn total_issuance() -> Self::Balance {
+		Pallet::<T>::total_issuance(GetCurrencyId::get())
+	}
+
+	fn minimum_balance() -> Self::Balance {
+		Pallet::<T>::minimum_balance(GetCurrencyId::get())
+	}
+
+	fn burn(mut amount: Self::Balance) -> Self::PositiveImbalance {
+		if amount.is_zero() {
+			return PositiveImbalance::zero();
+		}
+		<TotalIssuance<T>>::mutate(GetCurrencyId::get(), |issued| {
+			*issued = issued.checked_sub(&amount).unwrap_or_else(|| {
+				amount = *issued;
+				Zero::zero()
+			});
+		});
+		PositiveImbalance::new(amount)
+	}
+
+	fn issue(mut amount: Self::Balance) -> Self::NegativeImbalance {
+		if amount.is_zero() {
+			return NegativeImbalance::zero();
+		}
+		<TotalIssuance<T>>::mutate(GetCurrencyId::get(), |issued| {
+			*issued = issued.checked_add(&amount).unwrap_or_else(|| {
+				amount = Self::Balance::max_value() - *issued;
+				Self::Balance::max_value()
+			})
+		});
+		NegativeImbalance::new(amount)
+	}
+
+	fn free_balance(who: &T::AccountId) -> Self::Balance {
+		Pallet::<T>::free_balance(GetCurrencyId::get(), who)
+	}
+
+	fn ensure_can_withdraw(
+		who: &T::AccountId,
+		amount: Self::Balance,
+		_reasons: WithdrawReasons,
+		_new_balance: Self::Balance,
+	) -> DispatchResult {
+		Pallet::<T>::ensure_can_withdraw(GetCurrencyId::get(), who, amount)
+	}
+
+	fn transfer(
+		source: &T::AccountId,
+		dest: &T::AccountId,
+		value: Self::Balance,
+		_existence_requirement: ExistenceRequirement,
+	) -> DispatchResult {
+		<Pallet<T> as MultiCurrency<T::AccountId>>::transfer(GetCurrencyId::get(), &source, &dest, value)
+	}
+
+	fn slash(who: &T::AccountId, value: Self::Balance) -> (Self::NegativeImbalance, Self::Balance) {
+		if value.is_zero() {
+			return (Self::NegativeImbalance::zero(), value);
+		}
+
+		let currency_id = GetCurrencyId::get();
+		let account = Pallet::<T>::accounts(who, currency_id);
+		let free_slashed_amount = account.free.min(value);
+		let mut remaining_slash = value - free_slashed_amount;
+
+		// slash free balance
+		if !free_slashed_amount.is_zero() {
+			Pallet::<T>::set_free_balance(currency_id, who, account.free - free_slashed_amount);
+		}
+
+		// slash reserved balance
+		if !remaining_slash.is_zero() {
+			let reserved_slashed_amount = account.reserved.min(remaining_slash);
+			remaining_slash -= reserved_slashed_amount;
+			Pallet::<T>::set_reserved_balance(currency_id, who, account.reserved - reserved_slashed_amount);
+			(
+				Self::NegativeImbalance::new(free_slashed_amount + reserved_slashed_amount),
+				remaining_slash,
+			)
+		} else {
+			(Self::NegativeImbalance::new(value), remaining_slash)
+		}
+	}
+
+	fn deposit_into_existing(
+		who: &T::AccountId,
+		value: Self::Balance,
+	) -> sp_std::result::Result<Self::PositiveImbalance, DispatchError> {
+		if value.is_zero() {
+			return Ok(Self::PositiveImbalance::zero());
+		}
+		let currency_id = GetCurrencyId::get();
+		let new_total = Pallet::<T>::free_balance(currency_id, who)
+			.checked_add(&value)
+			.ok_or(Error::<T>::TotalIssuanceOverflow)?;
+		Pallet::<T>::set_free_balance(currency_id, who, new_total);
+
+		Ok(Self::PositiveImbalance::new(value))
+	}
+
+	fn deposit_creating(who: &T::AccountId, value: Self::Balance) -> Self::PositiveImbalance {
+		Self::deposit_into_existing(who, value).unwrap_or_else(|_| Self::PositiveImbalance::zero())
+	}
+
+	fn withdraw(
+		who: &T::AccountId,
+		value: Self::Balance,
+		_reasons: WithdrawReasons,
+		_liveness: ExistenceRequirement,
+	) -> sp_std::result::Result<Self::NegativeImbalance, DispatchError> {
+		if value.is_zero() {
+			return Ok(Self::NegativeImbalance::zero());
+		}
+		let currency_id = GetCurrencyId::get();
+		Pallet::<T>::ensure_can_withdraw(currency_id, who, value)?;
+		Pallet::<T>::set_free_balance(currency_id, who, Pallet::<T>::free_balance(currency_id, who) - value);
+
+		Ok(Self::NegativeImbalance::new(value))
+	}
+
+	fn make_free_balance_be(
+		who: &T::AccountId,
+		value: Self::Balance,
+	) -> SignedImbalance<Self::Balance, Self::PositiveImbalance> {
+		let currency_id = GetCurrencyId::get();
+		Pallet::<T>::try_mutate_account(
+			who,
+			currency_id,
+			|account, existed| -> Result<SignedImbalance<Self::Balance, Self::PositiveImbalance>, ()> {
+				// If we're attempting to set an existing account to less than ED, then
+				// bypass the entire operation. It's a no-op if you follow it through, but
+				// since this is an instance where we might account for a negative imbalance
+				// (in the dust cleaner of set_account) before we account for its actual
+				// equal and opposite cause (returned as an Imbalance), then in the
+				// instance that there's no other accounts on the system at all, we might
+				// underflow the issuance and our arithmetic will be off.
+				let ed = T::ExistentialDeposits::get(&currency_id);
+				ensure!(value.saturating_add(account.reserved) >= ed || existed, ());
+
+				let imbalance = if account.free <= value {
+					SignedImbalance::Positive(PositiveImbalance::new(value - account.free))
+				} else {
+					SignedImbalance::Negative(NegativeImbalance::new(account.free - value))
+				};
+				account.free = value;
+				Ok(imbalance)
+			},
+		)
+		.unwrap_or_else(|_| SignedImbalance::Positive(Self::PositiveImbalance::zero()))
+	}
+}
+
+impl<T, GetCurrencyId> PalletReservableCurrency<T::AccountId> for CurrencyAdapter<T, GetCurrencyId>
+where
+	T: Config,
+	GetCurrencyId: Get<T::CurrencyId>,
+{
+	fn can_reserve(who: &T::AccountId, value: Self::Balance) -> bool {
+		Pallet::<T>::can_reserve(GetCurrencyId::get(), who, value)
+	}
+
+	fn slash_reserved(who: &T::AccountId, value: Self::Balance) -> (Self::NegativeImbalance, Self::Balance) {
+		let actual = Pallet::<T>::slash_reserved(GetCurrencyId::get(), who, value);
+		(Self::NegativeImbalance::zero(), actual)
+	}
+
+	fn reserved_balance(who: &T::AccountId) -> Self::Balance {
+		Pallet::<T>::reserved_balance(GetCurrencyId::get(), who)
+	}
+
+	fn reserve(who: &T::AccountId, value: Self::Balance) -> DispatchResult {
+		Pallet::<T>::reserve(GetCurrencyId::get(), who, value)
+	}
+
+	fn unreserve(who: &T::AccountId, value: Self::Balance) -> Self::Balance {
+		Pallet::<T>::unreserve(GetCurrencyId::get(), who, value)
+	}
+
+	fn repatriate_reserved(
+		slashed: &T::AccountId,
+		beneficiary: &T::AccountId,
+		value: Self::Balance,
+		status: Status,
+	) -> sp_std::result::Result<Self::Balance, DispatchError> {
+		Pallet::<T>::repatriate_reserved(GetCurrencyId::get(), slashed, beneficiary, value, status)
+	}
+}
+
+impl<T, GetCurrencyId> PalletLockableCurrency<T::AccountId> for CurrencyAdapter<T, GetCurrencyId>
+where
+	T: Config,
+	GetCurrencyId: Get<T::CurrencyId>,
+{
+	type Moment = T::BlockNumber;
+	type MaxLocks = ();
+
+	fn set_lock(id: LockIdentifier, who: &T::AccountId, amount: Self::Balance, _reasons: WithdrawReasons) {
+		let _ = Pallet::<T>::set_lock(id, GetCurrencyId::get(), who, amount);
+	}
+
+	fn extend_lock(id: LockIdentifier, who: &T::AccountId, amount: Self::Balance, _reasons: WithdrawReasons) {
+		let _ = Pallet::<T>::extend_lock(id, GetCurrencyId::get(), who, amount);
+	}
+
+	fn remove_lock(id: LockIdentifier, who: &T::AccountId) {
+		let _ = Pallet::<T>::remove_lock(id, GetCurrencyId::get(), who);
+	}
+}
+
+impl<T: Config> MergeAccount<T::AccountId> for Pallet<T> {
+	#[transactional]
+	fn merge_account(source: &T::AccountId, dest: &T::AccountId) -> DispatchResult {
+		Accounts::<T>::iter_prefix(source).try_for_each(|(currency_id, account_data)| -> DispatchResult {
+			// ensure the account has no active reserved of non-native token
+			ensure!(account_data.reserved.is_zero(), Error::<T>::StillHasActiveReserved);
+
+			// transfer all free to recipient
+			<Self as MultiCurrency<T::AccountId>>::transfer(currency_id, source, dest, account_data.free)?;
+			Ok(())
+		})
 	}
 }

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -7,13 +7,9 @@ use frame_support::{
 	impl_outer_event, impl_outer_origin, parameter_types,
 	traits::{ChangeMembers, Contains, ContainsLengthBound, GenesisBuild, SaturatingCurrencyToVote},
 };
-use orml_traits::{parameter_type_with_key, LockIdentifier};
+use orml_traits::parameter_type_with_key;
 use sp_core::H256;
-use sp_runtime::{
-	testing::Header,
-	traits::{AccountIdConversion, IdentityLookup},
-	AccountId32, ModuleId, Permill,
-};
+use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32, Permill};
 use sp_std::cell::RefCell;
 
 pub type AccountId = AccountId32;

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -3,22 +3,8 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{
-	assert_noop, assert_ok,
-	traits::{
-		BalanceStatus as Status, Currency, ExistenceRequirement, LockableCurrency as PalletLockableCurrency,
-		ReservableCurrency as PalletReservableCurrency, WithdrawReasons,
-	},
-};
-use mock::{
-	Balance, DustAccount, ExtBuilder, Runtime, System, TestEvent, Tokens, Treasury, TreasuryCurrencyAdapter, ALICE,
-	BOB, BTC, DOT, ETH, ID_1, ID_2, TREASURY_ACCOUNT,
-};
-use orml_traits::{
-	account::MergeAccount, BalanceStatus, MultiCurrency, MultiCurrencyExtended, MultiLockableCurrency,
-	MultiReservableCurrency,
-};
-use sp_runtime::traits::Zero;
+use frame_support::{assert_noop, assert_ok};
+use mock::*;
 
 #[test]
 fn minimum_balance_work() {

--- a/vesting/src/mock.rs
+++ b/vesting/src/mock.rs
@@ -8,7 +8,6 @@ use frame_support::{
 	traits::{EnsureOrigin, GenesisBuild},
 };
 use frame_system::RawOrigin;
-use pallet_balances;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 

--- a/vesting/src/tests.rs
+++ b/vesting/src/tests.rs
@@ -3,12 +3,8 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{
-	assert_noop, assert_ok,
-	error::BadOrigin,
-	traits::{Currency, LockableCurrency, WithdrawReasons},
-};
-use mock::{ExtBuilder, Origin, PalletBalances, Runtime, System, TestEvent, Vesting, ALICE, BOB, CHARLIE};
+use frame_support::{assert_noop, assert_ok, error::BadOrigin};
+use mock::*;
 use pallet_balances::{BalanceLock, Reasons};
 
 #[test]


### PR DESCRIPTION
Apply some conventions of new pallet macro migration in Substrate:

1. Move imports out of `pub mod module/pallet`, to avoid re-import in mocks and tests.
2. `pub mod module/pallet` only includes `pallet` macro related code, such as `#[pallet::call]`, so that the structure could be more flattened.

Also includes other tiny-up like attribute annotations always go after documentation comments.