### PR TITLE
Add `transfer_all` to Currencies

### DIFF
--- a/currencies/src/default_weight.rs
+++ b/currencies/src/default_weight.rs
@@ -12,6 +12,11 @@ impl crate::WeightInfo for () {
 			.saturating_add(DbWeight::get().reads(5 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
+	fn transfer_all_non_native_currency() -> Weight {
+		(172_011_000 as Weight)
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
 	fn transfer_native_currency() -> Weight {
 		(43_023_000 as Weight)
 	}

--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -77,6 +77,7 @@ pub mod module {
 
 	pub trait WeightInfo {
 		fn transfer_non_native_currency() -> Weight;
+		fn transfer_all_non_native_currency() -> Weight;
 		fn transfer_native_currency() -> Weight;
 		fn update_balance_non_native_currency() -> Weight;
 		fn update_balance_native_currency_creating() -> Weight;
@@ -153,6 +154,24 @@ pub mod module {
 			let from = ensure_signed(origin)?;
 			let to = T::Lookup::lookup(dest)?;
 			<Self as MultiCurrency<T::AccountId>>::transfer(currency_id, &from, &to, amount)?;
+			Ok(().into())
+		}
+
+		/// Transfer all remaining balance to the given account under `currency_id`.
+		///
+		/// The dispatch origin for this call must be `Signed` by the
+		/// transactor.
+		#[pallet::weight(T::WeightInfo::transfer_all_non_native_currency())]
+		pub fn transfer_all(
+			origin: OriginFor<T>,
+			dest: <T::Lookup as StaticLookup>::Source,
+			currency_id: CurrencyIdOf<T>,
+		) -> DispatchResultWithPostInfo {
+			let from = ensure_signed(origin)?;
+			let to = T::Lookup::lookup(dest)?;
+			let balance = <Self as MultiCurrency<T::AccountId>>::free_balance(currency_id, &from);
+			<Self as MultiCurrency<T::AccountId>>::transfer(currency_id, &from, &to, balance)?;
+
 			Ok(().into())
 		}
 

--- a/currencies/src/lib.rs
+++ b/currencies/src/lib.rs
@@ -157,7 +157,8 @@ pub mod module {
 			Ok(().into())
 		}
 
-		/// Transfer all remaining balance to the given account under `currency_id`.
+		/// Transfer all remaining balance to the given account under
+		/// `currency_id`.
 		///
 		/// The dispatch origin for this call must be `Signed` by the
 		/// transactor.

--- a/currencies/src/tests.rs
+++ b/currencies/src/tests.rs
@@ -99,6 +99,18 @@ fn multi_currency_should_work() {
 }
 
 #[test]
+fn transfer_all_should_work() {
+	ExtBuilder::default()
+		.one_hundred_for_alice_n_bob()
+		.build()
+		.execute_with(|| {
+			assert_ok!(Currencies::transfer_all(Some(ALICE).into(), BOB, X_TOKEN_ID));
+			assert_eq!(Currencies::free_balance(X_TOKEN_ID, &ALICE), 0);
+			assert_eq!(Currencies::free_balance(X_TOKEN_ID, &BOB), 200);
+		});
+}
+
+#[test]
 fn multi_currency_extended_should_work() {
 	ExtBuilder::default()
 		.one_hundred_for_alice_n_bob()

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -336,7 +336,10 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let from = ensure_signed(origin)?;
 			let to = T::Lookup::lookup(dest)?;
-			let balance = <Self as MultiCurrency<T::AccountId>>::free_balance(currency_id, &from);
+
+			let frozen = Self::accounts(&from, currency_id).frozen();
+			let balance =
+				<Self as MultiCurrency<T::AccountId>>::free_balance(currency_id, &from).saturating_sub(frozen);
 			<Self as MultiCurrency<T::AccountId>>::transfer(currency_id, &from, &to, balance)?;
 
 			Self::deposit_event(Event::Transferred(currency_id, from, to, balance));

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -324,11 +324,12 @@ fn transfer_all_should_work() {
 		.execute_with(|| {
 			System::set_block_number(1);
 
+			assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 10));
 			assert_ok!(Tokens::transfer_all(Some(ALICE).into(), BOB, DOT));
-			assert_eq!(Tokens::free_balance(DOT, &ALICE), 0);
-			assert_eq!(Tokens::free_balance(DOT, &BOB), 200);
+			assert_eq!(Tokens::free_balance(DOT, &ALICE), 10);
+			assert_eq!(Tokens::free_balance(DOT, &BOB), 190);
 
-			let transferred_event = Event::tokens(crate::Event::Transferred(DOT, ALICE, BOB, 100));
+			let transferred_event = Event::tokens(crate::Event::Transferred(DOT, ALICE, BOB, 90));
 			assert!(System::events().iter().any(|record| record.event == transferred_event));
 		});
 }


### PR DESCRIPTION
**Changes**:
- Add `transfer_all` to currencies
- Add test for transfer_all

Not fully understand the requirements for # 375, for `tokens` module there has already have `transfer_all` function.

**Further steps**:
- [ ] Need to generate correct weight for `transfer_all_non_native_currency`