### PR TITLE
Bump and unify serde versions.

### DIFF
--- a/auction/Cargo.toml
+++ b/auction/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Acala Developers"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/authority/Cargo.toml
+++ b/authority/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Acala Developers"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/benchmarking/Cargo.toml
+++ b/benchmarking/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 paste = "0.1.16"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/currencies/Cargo.toml
+++ b/currencies/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/gradually-update/Cargo.toml
+++ b/gradually-update/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Acala Developers"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/rewards/Cargo.toml
+++ b/rewards/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Acala Developers"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
@@ -18,7 +18,7 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1",
 funty = { version = "=1.1.0", default-features = false } # https://github.com/bitvecto-rs/bitvec/issues/105
 
 [dev-dependencies]
-serde_json = "1.0.53"
+serde_json = "1.0.64"
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 
 [features]

--- a/vesting/Cargo.toml
+++ b/vesting/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }

--- a/xtokens/Cargo.toml
+++ b/xtokens/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Acala Developers"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.111", optional = true }
+serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }


### PR DESCRIPTION
Different serde and serde_json versions are declared in orml and acala cargo.toml, from `1.0` to `1.0.116`, this PR bumps and unifies them. Will open a companion PR in acala.