### PR TITLE
cleanup

### DIFF
--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -81,7 +81,3 @@ impl<T> Handler<T> for Tuple {
 		Ok(())
 	}
 }
-
-pub trait Contains<T> {
-	fn contains(t: &T) -> bool;
-}

--- a/utilities/src/ordered_set.rs
+++ b/utilities/src/ordered_set.rs
@@ -1,8 +1,8 @@
 use codec::{Decode, Encode};
 use frame_support::{traits::Get, BoundedVec, DefaultNoBound};
+use sp_std::convert::TryInto;
 #[cfg(feature = "std")]
-use sp_std::prelude::*;
-use sp_std::{convert::TryInto, fmt};
+use sp_std::{fmt, prelude::*};
 
 /// An ordered set backed by `BoundedVec`
 #[derive(PartialEq, Eq, Encode, Decode, DefaultNoBound, Clone)]


### PR DESCRIPTION
we have `frame_support::traits::Contains` so no need to have our own version
fixed a warning for std build