### PR TITLE
feat(oracle): invalidate aggragate when one of the values expires

### DIFF
--- a/oracle/src/default_combine_data.rs
+++ b/oracle/src/default_combine_data.rs
@@ -24,7 +24,11 @@ where
 		let now = T::Time::now();
 
 		values.retain(|x| x.timestamp + expires_in > now);
-		let valid_until = values.iter().map(|x| x.timestamp).min();
+		let valid_until = values
+			.iter()
+			.map(|x| x.timestamp)
+			.min()
+			.map(|timestamp| timestamp + expires_in);
 
 		let count = values.len() as u32;
 		let minimum_count = MinimumCount::get();

--- a/oracle/src/mock.rs
+++ b/oracle/src/mock.rs
@@ -69,7 +69,7 @@ impl Timestamp {
 
 parameter_types! {
 	pub const MinimumCount: u32 = 3;
-	pub const ExpiresIn: u32 = 600;
+	pub static ExpiresIn: u32 = 600;
 	pub const RootOperatorAccountId: AccountId = 4;
 	pub static OracleMembers: Vec<AccountId> = vec![1, 2, 3];
 }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -42,13 +42,14 @@ pub trait OnNewData<AccountId, Key, Value> {
 }
 
 /// Combine data provided by operators
-pub trait CombineData<Key, TimestampedValue> {
-	/// Combine data provided by operators
+pub trait CombineData<Key, TimestampedValue, ExpiresAt> {
+	/// Combine data provided by operators. Optionally includes an expiration
+	/// timestamp in the return value
 	fn combine_data(
 		key: &Key,
 		values: Vec<TimestampedValue>,
 		prev_value: Option<TimestampedValue>,
-	) -> Option<TimestampedValue>;
+	) -> Option<(TimestampedValue, Option<ExpiresAt>)>;
 }
 
 /// Indicate if should change a value


### PR DESCRIPTION
Addresses  #536. For context, each value has an associated timestamp, and the default `combine_data` function filters out expired ones. However, the aggregate used to be only updated when a new value is reported. With this PR, the aggregate is invalidated when the oldest value expires. To this end, `combine_data` was modified to return a `valid_until` timestamp. It is optional, because some users of the lib might not want to invalidate the aggregate ever - they would supply a custom `CombineData` type that returns None for the `valid_until` timestamp.

Unfortunately, this is a breaking change for existing users - I am not sure what the policy is for these.