### PR TITLE
Make 'XcmExecutionResult' type pub.

### DIFF
--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -21,7 +21,7 @@ pub use get_by_key::GetByKey;
 pub use nft::NFT;
 pub use price::{DefaultPriceProvider, PriceProvider};
 pub use rewards::RewardHandler;
-pub use xcm_transfer::XcmTransfer;
+pub use xcm_transfer::{XcmExecutionResult, XcmTransfer};
 
 pub mod arithmetic;
 pub mod auction;

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -2,7 +2,7 @@ use frame_support::dispatch::DispatchError;
 use frame_support::weights::Weight;
 use xcm::opaque::v0::{MultiAsset, MultiLocation, Outcome};
 
-type XcmExecutionResult = sp_std::result::Result<Outcome, DispatchError>;
+pub type XcmExecutionResult = sp_std::result::Result<Outcome, DispatchError>;
 
 /// Abstraction over cross-chain token transfers.
 pub trait XcmTransfer<AccountId, Balance, CurrencyId> {


### PR DESCRIPTION
It's used in the `pub` trait `XcmTransfer`, so it should be `pub` as well.