### PR TITLE
xtokens improvements

### DIFF
--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -21,7 +21,7 @@ pub use get_by_key::GetByKey;
 pub use nft::NFT;
 pub use price::{DefaultPriceProvider, PriceProvider};
 pub use rewards::RewardHandler;
-pub use xcm_transfer::{XcmExecutionResult, XcmTransfer};
+pub use xcm_transfer::XcmTransfer;
 
 pub mod arithmetic;
 pub mod auction;

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -1,8 +1,6 @@
-use frame_support::dispatch::DispatchError;
+use frame_support::dispatch::DispatchResult;
 use frame_support::weights::Weight;
-use xcm::opaque::v0::{MultiAsset, MultiLocation, Outcome};
-
-pub type XcmExecutionResult = sp_std::result::Result<Outcome, DispatchError>;
+use xcm::opaque::v0::{MultiAsset, MultiLocation};
 
 /// Abstraction over cross-chain token transfers.
 pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
@@ -13,7 +11,7 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		amount: Balance,
 		dest: MultiLocation,
 		dest_weight: Weight,
-	) -> XcmExecutionResult;
+	) -> DispatchResult;
 
 	/// Transfer `MultiAsset`
 	fn transfer_multi_asset(
@@ -21,5 +19,5 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		asset: MultiAsset,
 		dest: MultiLocation,
 		dest_weight: Weight,
-	) -> XcmExecutionResult;
+	) -> DispatchResult;
 }


### PR DESCRIPTION
- Make dispatchables calls fail on XCM execution error.
- Emit events in `XcmTransfer` trait.
- DRY in implementations.

Closes #584 
Closes #580