### PR TITLE
Limit Call size to 200 bytes

### DIFF
--- a/authority/src/lib.rs
+++ b/authority/src/lib.rs
@@ -267,7 +267,7 @@ pub mod module {
 		#[pallet::weight(T::WeightInfo::fast_track_scheduled_dispatch())]
 		pub fn fast_track_scheduled_dispatch(
 			origin: OriginFor<T>,
-			initial_origin: T::PalletsOrigin,
+			initial_origin: Box<T::PalletsOrigin>,
 			task_id: ScheduleTaskIndex,
 			when: DispatchTime<T::BlockNumber>,
 		) -> DispatchResult {
@@ -285,7 +285,7 @@ pub mod module {
 			T::Scheduler::reschedule_named((&initial_origin, task_id).encode(), when)
 				.map_err(|_| Error::<T>::FailedToFastTrack)?;
 
-			Self::deposit_event(Event::FastTracked(initial_origin, task_id, dispatch_at));
+			Self::deposit_event(Event::FastTracked(*initial_origin, task_id, dispatch_at));
 			Ok(())
 		}
 
@@ -293,7 +293,7 @@ pub mod module {
 		#[pallet::weight(T::WeightInfo::delay_scheduled_dispatch())]
 		pub fn delay_scheduled_dispatch(
 			origin: OriginFor<T>,
-			initial_origin: T::PalletsOrigin,
+			initial_origin: Box<T::PalletsOrigin>,
 			task_id: ScheduleTaskIndex,
 			additional_delay: T::BlockNumber,
 		) -> DispatchResult {
@@ -308,7 +308,7 @@ pub mod module {
 			let now = frame_system::Pallet::<T>::block_number();
 			let dispatch_at = now.saturating_add(additional_delay);
 
-			Self::deposit_event(Event::Delayed(initial_origin, task_id, dispatch_at));
+			Self::deposit_event(Event::Delayed(*initial_origin, task_id, dispatch_at));
 			Ok(())
 		}
 
@@ -316,13 +316,13 @@ pub mod module {
 		#[pallet::weight(T::WeightInfo::cancel_scheduled_dispatch())]
 		pub fn cancel_scheduled_dispatch(
 			origin: OriginFor<T>,
-			initial_origin: T::PalletsOrigin,
+			initial_origin: Box<T::PalletsOrigin>,
 			task_id: ScheduleTaskIndex,
 		) -> DispatchResult {
 			T::AuthorityConfig::check_cancel_schedule(origin, &initial_origin)?;
 			T::Scheduler::cancel_named((&initial_origin, task_id).encode()).map_err(|_| Error::<T>::FailedToCancel)?;
 
-			Self::deposit_event(Event::Cancelled(initial_origin, task_id));
+			Self::deposit_event(Event::Cancelled(*initial_origin, task_id));
 			Ok(())
 		}
 	}

--- a/authority/src/lib.rs
+++ b/authority/src/lib.rs
@@ -206,7 +206,11 @@ pub mod module {
 			let info = call.get_dispatch_info();
 			(T::WeightInfo::dispatch_as().saturating_add(info.weight), info.class)
 		})]
-		pub fn dispatch_as(origin: OriginFor<T>, as_origin: T::AsOriginId, call: Box<CallOf<T>>) -> DispatchResult {
+		pub fn dispatch_as(
+			origin: OriginFor<T>,
+			as_origin: Box<T::AsOriginId>,
+			call: Box<CallOf<T>>,
+		) -> DispatchResult {
 			as_origin.check_dispatch_from(origin)?;
 
 			let e = call.dispatch(as_origin.into_origin().into());

--- a/authority/src/lib.rs
+++ b/authority/src/lib.rs
@@ -206,11 +206,7 @@ pub mod module {
 			let info = call.get_dispatch_info();
 			(T::WeightInfo::dispatch_as().saturating_add(info.weight), info.class)
 		})]
-		pub fn dispatch_as(
-			origin: OriginFor<T>,
-			as_origin: Box<T::AsOriginId>,
-			call: Box<CallOf<T>>,
-		) -> DispatchResult {
+		pub fn dispatch_as(origin: OriginFor<T>, as_origin: T::AsOriginId, call: Box<CallOf<T>>) -> DispatchResult {
 			as_origin.check_dispatch_from(origin)?;
 
 			let e = call.dispatch(as_origin.into_origin().into());

--- a/authority/src/tests.rs
+++ b/authority/src/tests.rs
@@ -207,7 +207,7 @@ fn fast_track_scheduled_dispatch_work() {
 		let pallets_origin = schedule_origin.caller().clone();
 		assert_ok!(Authority::fast_track_scheduled_dispatch(
 			Origin::root(),
-			pallets_origin,
+			Box::new(pallets_origin),
 			0,
 			DispatchTime::At(4),
 		));
@@ -234,7 +234,7 @@ fn fast_track_scheduled_dispatch_work() {
 
 		assert_ok!(Authority::fast_track_scheduled_dispatch(
 			Origin::root(),
-			frame_system::RawOrigin::Root.into(),
+			Box::new(frame_system::RawOrigin::Root.into()),
 			1,
 			DispatchTime::At(4),
 		));
@@ -284,7 +284,7 @@ fn delay_scheduled_dispatch_work() {
 		let pallets_origin = schedule_origin.caller().clone();
 		assert_ok!(Authority::delay_scheduled_dispatch(
 			Origin::root(),
-			pallets_origin,
+			Box::new(pallets_origin),
 			0,
 			4,
 		));
@@ -311,7 +311,7 @@ fn delay_scheduled_dispatch_work() {
 
 		assert_ok!(Authority::delay_scheduled_dispatch(
 			Origin::root(),
-			frame_system::RawOrigin::Root.into(),
+			Box::new(frame_system::RawOrigin::Root.into()),
 			1,
 			4,
 		));
@@ -358,7 +358,11 @@ fn cancel_scheduled_dispatch_work() {
 		};
 
 		let pallets_origin = schedule_origin.caller().clone();
-		assert_ok!(Authority::cancel_scheduled_dispatch(Origin::root(), pallets_origin, 0));
+		assert_ok!(Authority::cancel_scheduled_dispatch(
+			Origin::root(),
+			Box::new(pallets_origin),
+			0
+		));
 		System::assert_last_event(mock::Event::Authority(Event::Cancelled(
 			OriginCaller::Authority(DelayedOrigin {
 				delay: 1,
@@ -381,7 +385,7 @@ fn cancel_scheduled_dispatch_work() {
 
 		assert_ok!(Authority::cancel_scheduled_dispatch(
 			Origin::root(),
-			frame_system::RawOrigin::Root.into(),
+			Box::new(frame_system::RawOrigin::Root.into()),
 			1
 		));
 		System::assert_last_event(mock::Event::Authority(Event::Cancelled(

--- a/authority/src/tests.rs
+++ b/authority/src/tests.rs
@@ -21,31 +21,31 @@ fn dispatch_as_work() {
 		let ensure_signed_call = Call::System(frame_system::Call::remark(vec![]));
 		assert_ok!(Authority::dispatch_as(
 			Origin::root(),
-			MockAsOriginId::Root,
+			Box::new(MockAsOriginId::Root),
 			Box::new(ensure_root_call)
 		));
 		assert_ok!(Authority::dispatch_as(
 			Origin::root(),
-			MockAsOriginId::Account1,
+			Box::new(MockAsOriginId::Account1),
 			Box::new(ensure_signed_call.clone())
 		));
 		assert_noop!(
 			Authority::dispatch_as(
 				Origin::signed(1),
-				MockAsOriginId::Root,
+				Box::new(MockAsOriginId::Root),
 				Box::new(ensure_signed_call.clone())
 			),
 			BadOrigin,
 		);
 		assert_ok!(Authority::dispatch_as(
 			Origin::signed(1),
-			MockAsOriginId::Account1,
+			Box::new(MockAsOriginId::Account1),
 			Box::new(ensure_signed_call.clone())
 		));
 		assert_noop!(
 			Authority::dispatch_as(
 				Origin::signed(1),
-				MockAsOriginId::Account2,
+				Box::new(MockAsOriginId::Account2),
 				Box::new(ensure_signed_call)
 			),
 			BadOrigin,
@@ -58,7 +58,7 @@ fn schedule_dispatch_at_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			MockAsOriginId::Root,
+			Box::new(MockAsOriginId::Root),
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -116,7 +116,7 @@ fn schedule_dispatch_after_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			MockAsOriginId::Root,
+			Box::new(MockAsOriginId::Root),
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -175,7 +175,7 @@ fn fast_track_scheduled_dispatch_work() {
 		System::set_block_number(1);
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			MockAsOriginId::Root,
+			Box::new(MockAsOriginId::Root),
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -252,7 +252,7 @@ fn delay_scheduled_dispatch_work() {
 		System::set_block_number(1);
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			MockAsOriginId::Root,
+			Box::new(MockAsOriginId::Root),
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -328,7 +328,7 @@ fn cancel_scheduled_dispatch_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			MockAsOriginId::Root,
+			Box::new(MockAsOriginId::Root),
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);

--- a/authority/src/tests.rs
+++ b/authority/src/tests.rs
@@ -390,3 +390,13 @@ fn cancel_scheduled_dispatch_work() {
 		)));
 	});
 }
+
+#[test]
+fn call_size_limit() {
+	assert!(
+		core::mem::size_of::<authority::Call::<Runtime>>() <= 200,
+		"size of Call is more than 200 bytes: some calls have too big arguments, use Box to \
+		reduce the size of Call.
+		If the limit is too strong, maybe consider increasing the limit",
+	);
+}

--- a/authority/src/tests.rs
+++ b/authority/src/tests.rs
@@ -21,31 +21,31 @@ fn dispatch_as_work() {
 		let ensure_signed_call = Call::System(frame_system::Call::remark(vec![]));
 		assert_ok!(Authority::dispatch_as(
 			Origin::root(),
-			Box::new(MockAsOriginId::Root),
+			MockAsOriginId::Root,
 			Box::new(ensure_root_call)
 		));
 		assert_ok!(Authority::dispatch_as(
 			Origin::root(),
-			Box::new(MockAsOriginId::Account1),
+			MockAsOriginId::Account1,
 			Box::new(ensure_signed_call.clone())
 		));
 		assert_noop!(
 			Authority::dispatch_as(
 				Origin::signed(1),
-				Box::new(MockAsOriginId::Root),
+				MockAsOriginId::Root,
 				Box::new(ensure_signed_call.clone())
 			),
 			BadOrigin,
 		);
 		assert_ok!(Authority::dispatch_as(
 			Origin::signed(1),
-			Box::new(MockAsOriginId::Account1),
+			MockAsOriginId::Account1,
 			Box::new(ensure_signed_call.clone())
 		));
 		assert_noop!(
 			Authority::dispatch_as(
 				Origin::signed(1),
-				Box::new(MockAsOriginId::Account2),
+				MockAsOriginId::Account2,
 				Box::new(ensure_signed_call)
 			),
 			BadOrigin,
@@ -58,7 +58,7 @@ fn schedule_dispatch_at_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			Box::new(MockAsOriginId::Root),
+			MockAsOriginId::Root,
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -116,7 +116,7 @@ fn schedule_dispatch_after_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			Box::new(MockAsOriginId::Root),
+			MockAsOriginId::Root,
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -175,7 +175,7 @@ fn fast_track_scheduled_dispatch_work() {
 		System::set_block_number(1);
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			Box::new(MockAsOriginId::Root),
+			MockAsOriginId::Root,
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -252,7 +252,7 @@ fn delay_scheduled_dispatch_work() {
 		System::set_block_number(1);
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			Box::new(MockAsOriginId::Root),
+			MockAsOriginId::Root,
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);
@@ -328,7 +328,7 @@ fn cancel_scheduled_dispatch_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let ensure_root_call = Call::System(frame_system::Call::fill_block(Perbill::one()));
 		let call = Call::Authority(authority::Call::dispatch_as(
-			Box::new(MockAsOriginId::Root),
+			MockAsOriginId::Root,
 			Box::new(ensure_root_call),
 		));
 		run_to_block(1);

--- a/xcm/Cargo.toml
+++ b/xcm/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
@@ -20,6 +21,7 @@ pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release
 default = ["std"]
 std = [
 	"codec/std",
+	"sp-std/std",
 	"frame-support/std",
 	"frame-system/std",
 	"xcm/std",

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -48,7 +48,11 @@ pub mod module {
 	impl<T: Config> Pallet<T> {
 		/// Send an XCM message as parachain sovereign.
 		#[pallet::weight(100_000_000)]
-		pub fn send_as_sovereign(origin: OriginFor<T>, dest: Box<MultiLocation>, message: Box<Xcm<()>>) -> DispatchResult {
+		pub fn send_as_sovereign(
+			origin: OriginFor<T>,
+			dest: Box<MultiLocation>,
+			message: Box<Xcm<()>>,
+		) -> DispatchResult {
 			let _ = T::SovereignOrigin::ensure_origin(origin)?;
 			pallet_xcm::Pallet::<T>::send_xcm(MultiLocation::Null, *dest.clone(), *message.clone()).map_err(
 				|e| match e {

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -5,6 +5,7 @@
 
 use frame_support::{pallet_prelude::*, traits::EnsureOrigin};
 use frame_system::pallet_prelude::*;
+use sp_std::boxed::Box;
 
 use xcm::v0::prelude::*;
 

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -48,15 +48,15 @@ pub mod module {
 	impl<T: Config> Pallet<T> {
 		/// Send an XCM message as parachain sovereign.
 		#[pallet::weight(100_000_000)]
-		pub fn send_as_sovereign(origin: OriginFor<T>, dest: MultiLocation, message: Xcm<()>) -> DispatchResult {
+		pub fn send_as_sovereign(origin: OriginFor<T>, dest: Box<MultiLocation>, message: Box<Xcm<()>>) -> DispatchResult {
 			let _ = T::SovereignOrigin::ensure_origin(origin)?;
-			pallet_xcm::Pallet::<T>::send_xcm(MultiLocation::Null, dest.clone(), message.clone()).map_err(
+			pallet_xcm::Pallet::<T>::send_xcm(MultiLocation::Null, *dest.clone(), *message.clone()).map_err(
 				|e| match e {
 					XcmError::CannotReachDestination(..) => Error::<T>::Unreachable,
 					_ => Error::<T>::SendFailure,
 				},
 			)?;
-			Self::deposit_event(Event::Sent(MultiLocation::Null, dest, message));
+			Self::deposit_event(Event::Sent(MultiLocation::Null, *dest, *message));
 			Ok(())
 		}
 	}

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -148,11 +148,11 @@ pub mod module {
 			origin: OriginFor<T>,
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
-			dest: MultiLocation,
+			dest: Box<MultiLocation>,
 			dest_weight: Weight,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			Self::do_transfer(who, currency_id, amount, dest, dest_weight)
+			Self::do_transfer(who, currency_id, amount, *dest, dest_weight)
 		}
 
 		/// Transfer `MultiAsset`.
@@ -171,12 +171,12 @@ pub mod module {
 		#[transactional]
 		pub fn transfer_multiasset(
 			origin: OriginFor<T>,
-			asset: MultiAsset,
-			dest: MultiLocation,
+			asset: Box<MultiAsset>,
+			dest: Box<MultiLocation>,
 			dest_weight: Weight,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			Self::do_transfer_multiasset(who, asset, dest, dest_weight, true)
+			Self::do_transfer_multiasset(who, *asset, *dest, dest_weight, true)
 		}
 	}
 

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -356,8 +356,8 @@ fn send_as_sovereign() {
 		let call = relay::Call::System(frame_system::Call::<relay::Runtime>::remark_with_event(vec![1, 1, 1]));
 		assert_ok!(para::OrmlXcm::send_as_sovereign(
 			para::Origin::root(),
-			Junction::Parent.into(),
-			WithdrawAsset {
+			Box::new(Junction::Parent.into()),
+			Box::new(WithdrawAsset {
 				assets: vec![MultiAsset::ConcreteFungible {
 					id: MultiLocation::Null,
 					amount: 1_000_000_000_000
@@ -373,7 +373,7 @@ fn send_as_sovereign() {
 						call: call.encode().into(),
 					}],
 				}]
-			}
+			})
 		));
 	});
 
@@ -402,8 +402,8 @@ fn send_as_sovereign_fails_if_bad_origin() {
 		assert_err!(
 			para::OrmlXcm::send_as_sovereign(
 				para::Origin::signed(ALICE),
-				Junction::Parent.into(),
-				WithdrawAsset {
+				Box::new(Junction::Parent.into()),
+				Box::new(WithdrawAsset {
 					assets: vec![MultiAsset::ConcreteFungible {
 						id: MultiLocation::Null,
 						amount: 1_000_000_000_000
@@ -419,7 +419,7 @@ fn send_as_sovereign_fails_if_bad_origin() {
 							call: call.encode().into(),
 						}],
 					}]
-				}
+				})
 			),
 			DispatchError::BadOrigin,
 		);

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -428,16 +428,8 @@ fn send_as_sovereign_fails_if_bad_origin() {
 
 #[test]
 fn call_size_limit() {
-	// Ensures Call enum doesn't allocate more than 200 bytes in runtime
 	assert!(
 		core::mem::size_of::<crate::Call::<crate::tests::para::Runtime>>() <= 200,
-		"size of Call is more than 200 bytes: some calls have too big arguments, use Box to \
-		reduce the size of Call.
-		If the limit is too strong, maybe consider increasing the limit",
-	);
-
-	assert!(
-		core::mem::size_of::<orml_xcm::Call::<crate::tests::para::Runtime>>() <= 200,
 		"size of Call is more than 200 bytes: some calls have too big arguments, use Box to \
 		reduce the size of Call.
 		If the limit is too strong, maybe consider increasing the limit",

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -429,8 +429,8 @@ fn send_as_sovereign_fails_if_bad_origin() {
 #[test]
 fn call_size_limit() {
 	assert!(
-		core::mem::size_of::<crate::Call::<crate::tests::para::Runtime>>() <= 230,
-		"size of Call is more than 230 bytes: some calls have too big arguments, use Box to \
+		core::mem::size_of::<crate::Call::<crate::tests::para::Runtime>>() <= 200,
+		"size of Call is more than 200 bytes: some calls have too big arguments, use Box to \
 		reduce the size of Call.
 		If the limit is too strong, maybe consider increasing the limit",
 	);

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -428,8 +428,16 @@ fn send_as_sovereign_fails_if_bad_origin() {
 
 #[test]
 fn call_size_limit() {
+	// Ensures Call enum doesn't allocate more than 200 bytes in runtime
 	assert!(
 		core::mem::size_of::<crate::Call::<crate::tests::para::Runtime>>() <= 200,
+		"size of Call is more than 200 bytes: some calls have too big arguments, use Box to \
+		reduce the size of Call.
+		If the limit is too strong, maybe consider increasing the limit",
+	);
+
+	assert!(
+		core::mem::size_of::<orml_xcm::Call::<crate::tests::para::Runtime>>() <= 200,
 		"size of Call is more than 200 bytes: some calls have too big arguments, use Box to \
 		reduce the size of Call.
 		If the limit is too strong, maybe consider increasing the limit",

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -47,13 +47,16 @@ fn send_relay_chain_asset_to_relay_chain() {
 			Some(ALICE).into(),
 			CurrencyId::R,
 			500,
-			Box::new((
-				Parent,
-				Junction::AccountId32 {
-					network: NetworkId::Kusama,
-					id: BOB.into(),
-				},
-			).into()),
+			Box::new(
+				(
+					Parent,
+					Junction::AccountId32 {
+						network: NetworkId::Kusama,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
 			30,
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 500);
@@ -76,14 +79,17 @@ fn cannot_lost_fund_on_send_failed() {
 				Some(ALICE).into(),
 				CurrencyId::A,
 				500,
-				Box::new((
-					Parent,
-					Parachain(100),
-					Junction::AccountId32 {
-						network: NetworkId::Kusama,
-						id: BOB.into(),
-					},
-				).into()),
+				Box::new(
+					(
+						Parent,
+						Parachain(100),
+						Junction::AccountId32 {
+							network: NetworkId::Kusama,
+							id: BOB.into(),
+						},
+					)
+						.into()
+				),
 				30,
 			),
 			Error::<para::Runtime>::XcmExecutionFailed
@@ -106,14 +112,17 @@ fn send_relay_chain_asset_to_sibling() {
 			Some(ALICE).into(),
 			CurrencyId::R,
 			500,
-			Box::new((
-				Parent,
-				Parachain(2),
-				Junction::AccountId32 {
-					network: NetworkId::Any,
-					id: BOB.into(),
-				},
-			).into()),
+			Box::new(
+				(
+					Parent,
+					Parachain(2),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
 			30,
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 500);
@@ -146,14 +155,17 @@ fn send_sibling_asset_to_reserve_sibling() {
 			Some(ALICE).into(),
 			CurrencyId::B,
 			500,
-			Box::new((
-				Parent,
-				Parachain(2),
-				Junction::AccountId32 {
-					network: NetworkId::Any,
-					id: BOB.into(),
-				},
-			).into()),
+			Box::new(
+				(
+					Parent,
+					Parachain(2),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
 			30,
 		));
 
@@ -183,14 +195,17 @@ fn send_sibling_asset_to_non_reserve_sibling() {
 			Some(ALICE).into(),
 			CurrencyId::B,
 			500,
-			Box::new((
-				Parent,
-				Parachain(3),
-				Junction::AccountId32 {
-					network: NetworkId::Any,
-					id: BOB.into(),
-				},
-			).into()),
+			Box::new(
+				(
+					Parent,
+					Parachain(3),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
 			30
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 500);
@@ -218,14 +233,17 @@ fn send_self_parachain_asset_to_sibling() {
 			Some(ALICE).into(),
 			CurrencyId::A,
 			500,
-			Box::new((
-				Parent,
-				Parachain(2),
-				Junction::AccountId32 {
-					network: NetworkId::Any,
-					id: BOB.into(),
-				},
-			).into()),
+			Box::new(
+				(
+					Parent,
+					Parachain(2),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
 			30,
 		));
 
@@ -250,14 +268,17 @@ fn transfer_no_reserve_assets_fails() {
 					id: GeneralKey("B".into()).into(),
 					amount: 100
 				}),
-				Box::new((
-					Parent,
-					Parachain(2),
-					Junction::AccountId32 {
-						network: NetworkId::Any,
-						id: BOB.into()
-					}
-				).into()),
+				Box::new(
+					(
+						Parent,
+						Parachain(2),
+						Junction::AccountId32 {
+							network: NetworkId::Any,
+							id: BOB.into()
+						}
+					)
+						.into()
+				),
 				50,
 			),
 			Error::<para::Runtime>::AssetHasNoReserve
@@ -277,14 +298,17 @@ fn transfer_to_self_chain_fails() {
 					id: (Parent, Parachain(1), GeneralKey("A".into())).into(),
 					amount: 100
 				}),
-				Box::new((
-					Parent,
-					Parachain(1),
-					Junction::AccountId32 {
-						network: NetworkId::Any,
-						id: BOB.into()
-					}
-				).into()),
+				Box::new(
+					(
+						Parent,
+						Parachain(1),
+						Junction::AccountId32 {
+							network: NetworkId::Any,
+							id: BOB.into()
+						}
+					)
+						.into()
+				),
 				50,
 			),
 			Error::<para::Runtime>::NotCrossChainTransfer
@@ -304,10 +328,13 @@ fn transfer_to_invalid_dest_fails() {
 					id: (Parent, Parachain(1), GeneralKey("A".into())).into(),
 					amount: 100,
 				}),
-				Box::new((Junction::AccountId32 {
-					network: NetworkId::Any,
-					id: BOB.into()
-				}).into()),
+				Box::new(
+					(Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into()
+					})
+					.into()
+				),
 				50,
 			),
 			Error::<para::Runtime>::InvalidDest
@@ -401,7 +428,8 @@ fn send_as_sovereign_fails_if_bad_origin() {
 
 #[test]
 fn call_size_limit() {
-	assert!(core::mem::size_of::<crate::Call::<crate::tests::para::Runtime>>() <= 230, 
+	assert!(
+		core::mem::size_of::<crate::Call::<crate::tests::para::Runtime>>() <= 230,
 		"size of Call is more than 230 bytes: some calls have too big arguments, use Box to \
 		reduce the size of Call.
 		If the limit is too strong, maybe consider increasing the limit",


### PR DESCRIPTION
The idea of this PR is to limit call length to 200 bytes for all orml pallets. It mirrors https://github.com/paritytech/substrate/pull/9418

Companion to https://github.com/AcalaNetwork/Acala/pull/1386

