### PR TITLE
Remove one space character

### DIFF
--- a/bencher/Cargo.toml
+++ b/bencher/Cargo.toml
@@ -29,7 +29,7 @@ sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, features = ["wasmtime"], optional = true }
 sc-executor-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", optional = true }
 sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, features = ["with-kvdb-rocksdb"], optional = true }
-sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate",  branch = "polkadot-v0.9.9", default-features = false, optional = true }
+sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 [features]


### PR DESCRIPTION
This tiny PR removes a stray space from a `Cargo.toml` file. This makes it easier to modify what Substrate and Polkadot branches are used with a script or search and replace.