### PR TITLE
bump pallet-elections-phragmen branch ref for tokens

### DIFF
--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -20,9 +20,7 @@ orml-traits = { path = "../traits", version = "0.4.1-dev", default-features = fa
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-# Patch doesn't work as `pallet-elections-phragmen` is now 4.0.0 version. Revert `rev` to `statemint` branch after
-# other `statemint` dependencies upgraded.
-pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", rev = "1d04678e20555e623c974ee1127bc8a45abcf3d6" }
+pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR is to bump the version of `pallet-elections-phragmen` used in `tokens`.  This addresses dependency conflicts as the pre-existing rev reference is associated with substrate v3.0.0. 

Fixes: #616 