### PR TITLE
Support multiple vesting schedules for the same account at genesis

### DIFF
--- a/vesting/src/lib.rs
+++ b/vesting/src/lib.rs
@@ -201,25 +201,30 @@ pub mod module {
 			self.vesting
 				.iter()
 				.for_each(|(who, start, period, period_count, per_period)| {
-					let total = *per_period * Into::<BalanceOf<T>>::into(*period_count);
-
-					let bounded_schedule: BoundedVec<VestingScheduleOf<T>, T::MaxVestingSchedules> =
-						vec![VestingSchedule {
+					let mut bounded_schedules = VestingSchedules::<T>::get(who);
+					bounded_schedules
+						.try_push(VestingSchedule {
 							start: *start,
 							period: *period,
 							period_count: *period_count,
 							per_period: *per_period,
-						}]
-						.try_into()
+						})
 						.expect("Max vesting schedules exceeded");
+					let total_amount = bounded_schedules
+						.iter()
+						.try_fold::<_, _, Result<BalanceOf<T>, DispatchError>>(Zero::zero(), |acc_amount, schedule| {
+							let amount = ensure_valid_vesting_schedule::<T>(schedule)?;
+							Ok(acc_amount + amount)
+						})
+						.expect("Invalid vesting schedule");
 
 					assert!(
-						T::Currency::free_balance(who) >= total,
+						T::Currency::free_balance(who) >= total_amount,
 						"Account do not have enough balance"
 					);
 
-					T::Currency::set_lock(VESTING_LOCK_ID, who, total, WithdrawReasons::all());
-					VestingSchedules::<T>::insert(who, bounded_schedule);
+					T::Currency::set_lock(VESTING_LOCK_ID, who, total_amount, WithdrawReasons::all());
+					VestingSchedules::<T>::insert(who, bounded_schedules);
 				});
 		}
 	}
@@ -319,7 +324,7 @@ impl<T: Config> Pallet<T> {
 
 	#[transactional]
 	fn do_vested_transfer(from: &T::AccountId, to: &T::AccountId, schedule: VestingScheduleOf<T>) -> DispatchResult {
-		let schedule_amount = Self::ensure_valid_vesting_schedule(&schedule)?;
+		let schedule_amount = ensure_valid_vesting_schedule::<T>(&schedule)?;
 
 		let total_amount = Self::locked_balance(to)
 			.checked_add(&schedule_amount)
@@ -346,7 +351,7 @@ impl<T: Config> Pallet<T> {
 		let total_amount = bounded_schedules
 			.iter()
 			.try_fold::<_, _, Result<BalanceOf<T>, DispatchError>>(Zero::zero(), |acc_amount, schedule| {
-				let amount = Self::ensure_valid_vesting_schedule(schedule)?;
+				let amount = ensure_valid_vesting_schedule::<T>(schedule)?;
 				Ok(acc_amount + amount)
 			})?;
 		ensure!(
@@ -359,17 +364,17 @@ impl<T: Config> Pallet<T> {
 
 		Ok(())
 	}
+}
 
-	/// Returns `Ok(amount)` if valid schedule, or error.
-	fn ensure_valid_vesting_schedule(schedule: &VestingScheduleOf<T>) -> Result<BalanceOf<T>, DispatchError> {
-		ensure!(!schedule.period.is_zero(), Error::<T>::ZeroVestingPeriod);
-		ensure!(!schedule.period_count.is_zero(), Error::<T>::ZeroVestingPeriodCount);
-		ensure!(schedule.end().is_some(), ArithmeticError::Overflow);
+/// Returns `Ok(total_total)` if valid schedule, or error.
+fn ensure_valid_vesting_schedule<T: Config>(schedule: &VestingScheduleOf<T>) -> Result<BalanceOf<T>, DispatchError> {
+	ensure!(!schedule.period.is_zero(), Error::<T>::ZeroVestingPeriod);
+	ensure!(!schedule.period_count.is_zero(), Error::<T>::ZeroVestingPeriodCount);
+	ensure!(schedule.end().is_some(), ArithmeticError::Overflow);
 
-		let total = schedule.total_amount().ok_or(ArithmeticError::Overflow)?;
+	let total_total = schedule.total_amount().ok_or(ArithmeticError::Overflow)?;
 
-		ensure!(total >= T::MinVestedTransfer::get(), Error::<T>::AmountLow);
+	ensure!(total_total >= T::MinVestedTransfer::get(), Error::<T>::AmountLow);
 
-		Ok(total)
-	}
+	Ok(total_total)
 }

--- a/vesting/src/mock.rs
+++ b/vesting/src/mock.rs
@@ -133,13 +133,17 @@ impl ExtBuilder {
 			.unwrap();
 
 		pallet_balances::GenesisConfig::<Runtime> {
-			balances: vec![(ALICE, 100), (CHARLIE, 30)],
+			balances: vec![(ALICE, 100), (CHARLIE, 50)],
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();
 
 		vesting::GenesisConfig::<Runtime> {
-			vesting: vec![(CHARLIE, 2, 3, 4, 5)], // who, start, period, period_count, per_period
+			vesting: vec![
+				// who, start, period, period_count, per_period
+				(CHARLIE, 2, 3, 1, 5),
+				(CHARLIE, 2 + 3, 3, 3, 5),
+			],
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();

--- a/vesting/src/tests.rs
+++ b/vesting/src/tests.rs
@@ -20,12 +20,20 @@ fn vesting_from_chain_spec_works() {
 
 		assert_eq!(
 			Vesting::vesting_schedules(&CHARLIE),
-			vec![VestingSchedule {
-				start: 2u64,
-				period: 3u64,
-				period_count: 4u32,
-				per_period: 5u64,
-			}]
+			vec![
+				VestingSchedule {
+					start: 2u64,
+					period: 3u64,
+					period_count: 1u32,
+					per_period: 5u64,
+				},
+				VestingSchedule {
+					start: 2u64 + 3u64,
+					period: 3u64,
+					period_count: 3u32,
+					per_period: 5u64,
+				}
+			]
 		);
 
 		MockBlockNumberProvider::set(13);


### PR DESCRIPTION
This functionality was already supported in `update_vesting_schedules()`, but not in genesis configuration for some reason