### PR TITLE
Fix/repatriate emit event

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -250,8 +250,8 @@ pub mod module {
 		/// \[currency_id, who, value\]
 		Unreserved(T::CurrencyId, T::AccountId, T::Balance),
 		/// Some reserved balance was repatriated (moved from reserved to
-		/// another account). \[currency_id, slashed, beneficiary, value,
-		/// status\]
+		/// another account).
+		/// \[currency_id, from, to, amount_actually_moved, status\]
 		RepatriatedReserve(T::CurrencyId, T::AccountId, T::AccountId, T::Balance, BalanceStatus),
 		/// A balance was set by root. \[who, free, reserved\]
 		BalanceSet(T::CurrencyId, T::AccountId, T::Balance, T::Balance),

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -249,6 +249,9 @@ pub mod module {
 		/// Some balance was unreserved (moved from reserved to free).
 		/// \[currency_id, who, value\]
 		Unreserved(T::CurrencyId, T::AccountId, T::Balance),
+		/// Some balance was repatriated (moved from reserved to another
+		/// account). \[currency_id, slashed, beneficiary, value, status\]
+		Repatriated(T::CurrencyId, T::AccountId, T::AccountId, T::Balance, BalanceStatus),
 		/// A balance was set by root. \[who, free, reserved\]
 		BalanceSet(T::CurrencyId, T::AccountId, T::Balance, T::Balance),
 	}
@@ -1196,6 +1199,13 @@ impl<T: Config> MultiReservableCurrency<T::AccountId> for Pallet<T> {
 			}
 		}
 		Self::set_reserved_balance(currency_id, slashed, from_account.reserved - actual);
+		Self::deposit_event(Event::<T>::Repatriated(
+			currency_id,
+			slashed.clone(),
+			beneficiary.clone(),
+			actual,
+			status,
+		));
 		Ok(value - actual)
 	}
 }

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -249,9 +249,10 @@ pub mod module {
 		/// Some balance was unreserved (moved from reserved to free).
 		/// \[currency_id, who, value\]
 		Unreserved(T::CurrencyId, T::AccountId, T::Balance),
-		/// Some balance was repatriated (moved from reserved to another
-		/// account). \[currency_id, slashed, beneficiary, value, status\]
-		Repatriated(T::CurrencyId, T::AccountId, T::AccountId, T::Balance, BalanceStatus),
+		/// Some reserved balance was repatriated (moved from reserved to
+		/// another account). \[currency_id, slashed, beneficiary, value,
+		/// status\]
+		RepatriatedReserve(T::CurrencyId, T::AccountId, T::AccountId, T::Balance, BalanceStatus),
 		/// A balance was set by root. \[who, free, reserved\]
 		BalanceSet(T::CurrencyId, T::AccountId, T::Balance, T::Balance),
 	}
@@ -1199,7 +1200,7 @@ impl<T: Config> MultiReservableCurrency<T::AccountId> for Pallet<T> {
 			}
 		}
 		Self::set_reserved_balance(currency_id, slashed, from_account.reserved - actual);
-		Self::deposit_event(Event::<T>::Repatriated(
+		Self::deposit_event(Event::<T>::RepatriatedReserve(
 			currency_id,
 			slashed.clone(),
 			beneficiary.clone(),

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -1343,7 +1343,7 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &BOB, &ALICE, 30, BalanceStatus::Reserved),
 				Ok(0)
 			);
-			System::assert_last_event(Event::Tokens(crate::Event::Repatriated(
+			System::assert_last_event(Event::Tokens(crate::Event::RepatriatedReserve(
 				DOT,
 				BOB,
 				ALICE,
@@ -1360,7 +1360,7 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &BOB, &ALICE, 30, BalanceStatus::Free),
 				Ok(10)
 			);
-			System::assert_last_event(Event::Tokens(crate::Event::Repatriated(
+			System::assert_last_event(Event::Tokens(crate::Event::RepatriatedReserve(
 				DOT,
 				BOB,
 				ALICE,

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -1321,6 +1321,8 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &ALICE, &ALICE, 50, BalanceStatus::Free),
 				Ok(50)
 			);
+			System::assert_last_event(Event::Tokens(crate::Event::Unreserved(DOT, ALICE, 0)));
+
 			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
 			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 0);
 
@@ -1333,6 +1335,7 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &BOB, &BOB, 60, BalanceStatus::Reserved),
 				Ok(10)
 			);
+
 			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);
 			assert_eq!(Tokens::reserved_balance(DOT, &BOB), 50);
 
@@ -1340,6 +1343,14 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &BOB, &ALICE, 30, BalanceStatus::Reserved),
 				Ok(0)
 			);
+			System::assert_last_event(Event::Tokens(crate::Event::Repatriated(
+				DOT,
+				BOB,
+				ALICE,
+				30,
+				BalanceStatus::Reserved,
+			)));
+
 			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
 			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 30);
 			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);
@@ -1349,6 +1360,14 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &BOB, &ALICE, 30, BalanceStatus::Free),
 				Ok(10)
 			);
+			System::assert_last_event(Event::Tokens(crate::Event::Repatriated(
+				DOT,
+				BOB,
+				ALICE,
+				20,
+				BalanceStatus::Free,
+			)));
+
 			assert_eq!(Tokens::free_balance(DOT, &ALICE), 120);
 			assert_eq!(Tokens::reserved_balance(DOT, &ALICE), 30);
 			assert_eq!(Tokens::free_balance(DOT, &BOB), 50);

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -1321,6 +1321,7 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &ALICE, &ALICE, 50, BalanceStatus::Free),
 				Ok(50)
 			);
+			// Repatriating from and to the same account, fund is `unreserved`.
 			System::assert_last_event(Event::Tokens(crate::Event::Unreserved(DOT, ALICE, 0)));
 
 			assert_eq!(Tokens::free_balance(DOT, &ALICE), 100);
@@ -1360,6 +1361,8 @@ fn multi_reservable_currency_repatriate_reserved_work() {
 				Tokens::repatriate_reserved(DOT, &BOB, &ALICE, 30, BalanceStatus::Free),
 				Ok(10)
 			);
+
+			// Actual amount repatriated is 20.
 			System::assert_last_event(Event::Tokens(crate::Event::RepatriatedReserve(
 				DOT,
 				BOB,


### PR DESCRIPTION
orml_tokens module now emit event when funds are repatriated.
Updated orml_tokens unit tests to test that the new RepatriatedReserved is correctly emitted