### PR TITLE
xtokens: ensuring exact error from xcm propagated

### DIFF
--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -134,6 +134,91 @@ pub mod module {
 		/// The version of the `Versioned` value used is not able to be
 		/// interpreted.
 		BadVersion,
+		/// same as  XCM underlying error
+		XcmOverflow,
+		/// same as  XCM underlying error
+		XcmUnimplemented,
+		/// same as  XCM underlying error
+		XcmUntrustedReserveLocation,
+		/// same as  XCM underlying error
+		XcmUntrustedTeleportLocation,
+		/// same as  XCM underlying error
+		XcmMultiLocationFull,
+		/// same as  XCM underlying error
+		XcmMultiLocationNotInvertible,
+		/// same as  XCM underlying error
+		XcmBadOrigin,
+		/// same as  XCM underlying error
+		XcmInvalidLocation,
+		/// same as  XCM underlying error
+		XcmAssetNotFound,
+		/// same as  XCM underlying error
+		XcmFailedToTransactAsset,
+		/// same as  XCM underlying error
+		XcmNotWithdrawable,
+		/// same as  XCM underlying error
+		XcmLocationCannotHold,
+		/// same as  XCM underlying error
+		XcmExceedsMaxMessageSize,
+		/// same as  XCM underlying error
+		XcmDestinationUnsupported,
+		/// same as  XCM underlying error
+		XcmTransport,
+		/// same as  XCM underlying error
+		XcmUnroutable,
+		/// same as  XCM underlying error
+		XcmUnknownClaim,
+		/// same as  XCM underlying error
+		XcmFailedToDecode,
+		/// same as  XCM underlying error
+		XcmTooMuchWeightRequired,
+		/// same as  XCM underlying error
+		XcmNotHoldingFees,
+		/// same as  XCM underlying error
+		XcmTooExpensive,
+		/// same as  XCM underlying error
+		XcmTrap,
+		/// same as  XCM underlying error
+		XcmUnhandledXcmVersion,
+		/// same as  XCM underlying error
+		XcmWeightLimitReached,
+		/// same as  XCM underlying error
+		XcmBarrier,
+		/// same as  XCM underlying error
+		XcmWeightNotComputable,
+	}
+
+	/// Maps xcm error for detailed response in pallet.
+	/// Make sure that Xcm transfers are debugable.
+	fn xcm_to_pallet_error<T>(error: XcmError) -> Error<T> {
+		match error {
+			XcmError::Overflow => Error::<T>::XcmOverflow,
+			XcmError::Unimplemented => Error::<T>::XcmUnimplemented,
+			XcmError::UntrustedReserveLocation => Error::<T>::XcmUntrustedReserveLocation,
+			XcmError::UntrustedTeleportLocation => Error::<T>::XcmUntrustedTeleportLocation,
+			XcmError::MultiLocationFull => Error::<T>::XcmMultiLocationFull,
+			XcmError::MultiLocationNotInvertible => Error::<T>::XcmMultiLocationNotInvertible,
+			XcmError::BadOrigin => Error::<T>::XcmBadOrigin,
+			XcmError::InvalidLocation => Error::<T>::XcmInvalidLocation,
+			XcmError::AssetNotFound => Error::<T>::XcmAssetNotFound,
+			XcmError::FailedToTransactAsset(_) => Error::<T>::XcmFailedToTransactAsset,
+			XcmError::NotWithdrawable => Error::<T>::XcmNotWithdrawable,
+			XcmError::LocationCannotHold => Error::<T>::XcmLocationCannotHold,
+			XcmError::ExceedsMaxMessageSize => Error::<T>::XcmExceedsMaxMessageSize,
+			XcmError::DestinationUnsupported => Error::<T>::XcmDestinationUnsupported,
+			XcmError::Transport(_) => Error::<T>::XcmTransport,
+			XcmError::Unroutable => Error::<T>::XcmUnroutable,
+			XcmError::UnknownClaim => Error::<T>::XcmUnknownClaim,
+			XcmError::FailedToDecode => Error::<T>::XcmFailedToDecode,
+			XcmError::TooMuchWeightRequired => Error::<T>::XcmTooMuchWeightRequired,
+			XcmError::NotHoldingFees => Error::<T>::XcmNotHoldingFees,
+			XcmError::TooExpensive => Error::<T>::XcmTooExpensive,
+			XcmError::Trap(_) => Error::<T>::XcmTrap,
+			XcmError::UnhandledXcmVersion => Error::<T>::XcmUnhandledXcmVersion,
+			XcmError::WeightLimitReached(_) => Error::<T>::XcmWeightLimitReached,
+			XcmError::Barrier => Error::<T>::XcmBarrier,
+			XcmError::WeightNotComputable => Error::<T>::XcmWeightNotComputable,
+		}
 	}
 
 	#[pallet::hooks]
@@ -245,7 +330,7 @@ pub mod module {
 			let weight = T::Weigher::weight(&mut msg).map_err(|()| Error::<T>::UnweighableMessage)?;
 			T::XcmExecutor::execute_xcm_in_credit(origin_location, msg, weight, weight)
 				.ensure_complete()
-				.map_err(|_| Error::<T>::XcmExecutionFailed)?;
+				.map_err(xcm_to_pallet_error::<T>)?;
 
 			if deposit_event {
 				Self::deposit_event(Event::<T>::TransferredMultiAsset(who, asset, dest));

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -22,7 +22,7 @@
 #![allow(clippy::unused_unit)]
 #![allow(clippy::large_enum_variant)]
 
-use frame_support::{pallet_prelude::*, require_transactional, traits::Get, transactional, Parameter};
+use frame_support::{log, pallet_prelude::*, require_transactional, traits::Get, transactional, Parameter};
 use frame_system::{ensure_signed, pallet_prelude::*};
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Convert, MaybeSerializeDeserialize, Member, Zero},
@@ -54,6 +54,7 @@ use TransferKind::*;
 
 #[frame_support::pallet]
 pub mod module {
+
 	use super::*;
 
 	#[pallet::config]
@@ -120,6 +121,7 @@ pub mod module {
 		NotCrossChainTransferableCurrency,
 		/// The message's weight could not be determined.
 		UnweighableMessage,
+		// TODO: expand into XcmExecutionFailed(XcmError) after https://github.com/paritytech/substrate/pull/10242 done
 		/// XCM execution failed.
 		XcmExecutionFailed,
 		/// Could not re-anchor the assets to declare the fees for the
@@ -134,91 +136,6 @@ pub mod module {
 		/// The version of the `Versioned` value used is not able to be
 		/// interpreted.
 		BadVersion,
-		/// same as  XCM underlying error
-		XcmOverflow,
-		/// same as  XCM underlying error
-		XcmUnimplemented,
-		/// same as  XCM underlying error
-		XcmUntrustedReserveLocation,
-		/// same as  XCM underlying error
-		XcmUntrustedTeleportLocation,
-		/// same as  XCM underlying error
-		XcmMultiLocationFull,
-		/// same as  XCM underlying error
-		XcmMultiLocationNotInvertible,
-		/// same as  XCM underlying error
-		XcmBadOrigin,
-		/// same as  XCM underlying error
-		XcmInvalidLocation,
-		/// same as  XCM underlying error
-		XcmAssetNotFound,
-		/// same as  XCM underlying error
-		XcmFailedToTransactAsset,
-		/// same as  XCM underlying error
-		XcmNotWithdrawable,
-		/// same as  XCM underlying error
-		XcmLocationCannotHold,
-		/// same as  XCM underlying error
-		XcmExceedsMaxMessageSize,
-		/// same as  XCM underlying error
-		XcmDestinationUnsupported,
-		/// same as  XCM underlying error
-		XcmTransport,
-		/// same as  XCM underlying error
-		XcmUnroutable,
-		/// same as  XCM underlying error
-		XcmUnknownClaim,
-		/// same as  XCM underlying error
-		XcmFailedToDecode,
-		/// same as  XCM underlying error
-		XcmTooMuchWeightRequired,
-		/// same as  XCM underlying error
-		XcmNotHoldingFees,
-		/// same as  XCM underlying error
-		XcmTooExpensive,
-		/// same as  XCM underlying error
-		XcmTrap,
-		/// same as  XCM underlying error
-		XcmUnhandledXcmVersion,
-		/// same as  XCM underlying error
-		XcmWeightLimitReached,
-		/// same as  XCM underlying error
-		XcmBarrier,
-		/// same as  XCM underlying error
-		XcmWeightNotComputable,
-	}
-
-	/// Maps xcm error for detailed response in pallet.
-	/// Make sure that Xcm transfers are debugable.
-	fn xcm_to_pallet_error<T>(error: XcmError) -> Error<T> {
-		match error {
-			XcmError::Overflow => Error::<T>::XcmOverflow,
-			XcmError::Unimplemented => Error::<T>::XcmUnimplemented,
-			XcmError::UntrustedReserveLocation => Error::<T>::XcmUntrustedReserveLocation,
-			XcmError::UntrustedTeleportLocation => Error::<T>::XcmUntrustedTeleportLocation,
-			XcmError::MultiLocationFull => Error::<T>::XcmMultiLocationFull,
-			XcmError::MultiLocationNotInvertible => Error::<T>::XcmMultiLocationNotInvertible,
-			XcmError::BadOrigin => Error::<T>::XcmBadOrigin,
-			XcmError::InvalidLocation => Error::<T>::XcmInvalidLocation,
-			XcmError::AssetNotFound => Error::<T>::XcmAssetNotFound,
-			XcmError::FailedToTransactAsset(_) => Error::<T>::XcmFailedToTransactAsset,
-			XcmError::NotWithdrawable => Error::<T>::XcmNotWithdrawable,
-			XcmError::LocationCannotHold => Error::<T>::XcmLocationCannotHold,
-			XcmError::ExceedsMaxMessageSize => Error::<T>::XcmExceedsMaxMessageSize,
-			XcmError::DestinationUnsupported => Error::<T>::XcmDestinationUnsupported,
-			XcmError::Transport(_) => Error::<T>::XcmTransport,
-			XcmError::Unroutable => Error::<T>::XcmUnroutable,
-			XcmError::UnknownClaim => Error::<T>::XcmUnknownClaim,
-			XcmError::FailedToDecode => Error::<T>::XcmFailedToDecode,
-			XcmError::TooMuchWeightRequired => Error::<T>::XcmTooMuchWeightRequired,
-			XcmError::NotHoldingFees => Error::<T>::XcmNotHoldingFees,
-			XcmError::TooExpensive => Error::<T>::XcmTooExpensive,
-			XcmError::Trap(_) => Error::<T>::XcmTrap,
-			XcmError::UnhandledXcmVersion => Error::<T>::XcmUnhandledXcmVersion,
-			XcmError::WeightLimitReached(_) => Error::<T>::XcmWeightLimitReached,
-			XcmError::Barrier => Error::<T>::XcmBarrier,
-			XcmError::WeightNotComputable => Error::<T>::XcmWeightNotComputable,
-		}
 	}
 
 	#[pallet::hooks]
@@ -330,7 +247,10 @@ pub mod module {
 			let weight = T::Weigher::weight(&mut msg).map_err(|()| Error::<T>::UnweighableMessage)?;
 			T::XcmExecutor::execute_xcm_in_credit(origin_location, msg, weight, weight)
 				.ensure_complete()
-				.map_err(xcm_to_pallet_error::<T>)?;
+				.map_err(|error| {
+					log::trace!("Failed execute transfer message with {:?}", error);
+					Error::<T>::XcmExecutionFailed
+				})?;
 
 			if deposit_event {
 				Self::deposit_event(Event::<T>::TransferredMultiAsset(who, asset, dest));

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -248,7 +248,7 @@ pub mod module {
 			T::XcmExecutor::execute_xcm_in_credit(origin_location, msg, weight, weight)
 				.ensure_complete()
 				.map_err(|error| {
-					log::trace!("Failed execute transfer message with {:?}", error);
+					log::error!("Failed execute transfer message with {:?}", error);
 					Error::<T>::XcmExecutionFailed
 				})?;
 

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -101,7 +101,7 @@ fn cannot_lost_fund_on_send_failed() {
 				),
 				40,
 			),
-			Error::<para::Runtime>::XcmUnroutable
+			Error::<para::Runtime>::XcmExecutionFailed
 		);
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 1_000);

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -101,7 +101,7 @@ fn cannot_lost_fund_on_send_failed() {
 				),
 				40,
 			),
-			Error::<para::Runtime>::XcmExecutionFailed
+			Error::<para::Runtime>::XcmUnroutable
 		);
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 1_000);


### PR DESCRIPTION
xcmp may fail because of dozens of reasons. it is very hard to debug and hard to setup. 
so solution is to be very specific about failure reason.