### PR TITLE
Allow to check arbitrary PreConditions before transfers

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -235,6 +235,8 @@ pub mod module {
 		ExistentialDeposit,
 		/// Beneficiary account must pre-exist
 		DeadAccount,
+		/// The pre-conditions for this transfer are not met
+		PreConditionsNotMet
 	}
 
 	#[pallet::event]

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -162,6 +162,17 @@ pub struct TransferDetails<AccountId, CurrencyId, Balance> {
 	amount: Balance,
 }
 
+impl<AccountId, CurrencyId, Balance> TransferDetails<AccountId, CurrencyId, Balance> {
+	pub fn new(send: AccountId, recv: AccountId, id: CurrencyId, amount: Balance) -> Self {
+		TransferDetails {
+			send,
+			recv,
+			id,
+			amount
+		}
+	}
+}
+
 pub use module::*;
 
 #[frame_support::pallet]
@@ -406,7 +417,7 @@ pub mod module {
 			let to = T::Lookup::lookup(dest)?;
 
 			ensure!(
-				T::PreConditions::check(from, to, currency_id, amount),
+				T::PreConditions::check(TransferDetails::new(from, to, currency_id, amount)),
 				Error::<T>::PreConditionsNotMet,
 			);
 
@@ -454,7 +465,7 @@ pub mod module {
 				<Self as fungibles::Inspect<T::AccountId>>::reducible_balance(currency_id, &from, keep_alive);
 
 			ensure!(
-				T::PreConditions::check(from, to, currency_id, reducible_balance),
+				T::PreConditions::check(TransferDetails::new(from, to, currency_id, amount)),
 				Error::<T>::PreConditionsNotMet,
 			);
 
@@ -491,7 +502,7 @@ pub mod module {
 			let to = T::Lookup::lookup(dest)?;
 
 			ensure!(
-				T::PreConditions::check(from, to, currency_id, reducible_balance),
+				T::PreConditions::check(TransferDetails::new(from, to, currency_id, amount)),
 				Error::<T>::PreConditionsNotMet,
 			);
 

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -417,8 +417,13 @@ pub mod module {
 			let to = T::Lookup::lookup(dest)?;
 
 			ensure!(
-				T::PreConditions::check(TransferDetails::new(from, to, currency_id, amount)),
-				Error::<T>::PreConditionsNotMet,
+				T::PreConditions::check(TransferDetails::new(
+					from.clone(),
+					to.clone(),
+					currency_id,
+					amount
+				)),
+				Error::<T>::PreConditionsNotMet
 			);
 
 			Self::do_transfer(currency_id, &from, &to, amount, ExistenceRequirement::AllowDeath)?;
@@ -465,8 +470,13 @@ pub mod module {
 				<Self as fungibles::Inspect<T::AccountId>>::reducible_balance(currency_id, &from, keep_alive);
 
 			ensure!(
-				T::PreConditions::check(TransferDetails::new(from, to, currency_id, amount)),
-				Error::<T>::PreConditionsNotMet,
+				T::PreConditions::check(TransferDetails::new(
+					from.clone(),
+					to.clone(),
+					currency_id,
+					amount
+				)),
+				Error::<T>::PreConditionsNotMet
 			);
 
 			<Self as fungibles::Transfer<_>>::transfer(currency_id, &from, &to, reducible_balance, keep_alive)?;
@@ -502,8 +512,13 @@ pub mod module {
 			let to = T::Lookup::lookup(dest)?;
 
 			ensure!(
-				T::PreConditions::check(TransferDetails::new(from, to, currency_id, amount)),
-				Error::<T>::PreConditionsNotMet,
+				T::PreConditions::check(TransferDetails::new(
+					from.clone(),
+					to.clone(),
+					currency_id,
+					amount
+				)),
+				Error::<T>::PreConditionsNotMet
 			);
 
 			Self::do_transfer(currency_id, &from, &to, amount, ExistenceRequirement::KeepAlive)?;

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 	traits::{ChangeMembers, ContainsLengthBound, Everything, GenesisBuild, SaturatingCurrencyToVote, SortedMembers},
 	PalletId,
 };
-use orml_traits::parameter_type_with_key;
+use orml_traits::{parameter_type_with_key, Always};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -232,6 +232,7 @@ impl Config for Runtime {
 	type Amount = i64;
 	type CurrencyId = CurrencyId;
 	type WeightInfo = ();
+	type PreConditions = Always;
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = TransferDust<Runtime, DustReceiver>;
 	type MaxLocks = MaxLocks;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -91,7 +91,7 @@ pub trait PreConditions<T> {
 	fn check(t: &T) -> bool;
 }
 
-#[impl_for_tuples(10)]
+#[impl_for_tuples(1, 10)]
 impl<T> PreConditions<T> for Tuple {
 	fn check(t: &T) -> bool {
 		for_tuples!( #( Tuple::check(t) )&* )

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -100,16 +100,16 @@ impl<T> PreConditions<T> for Tuple {
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct Always;
-impl PreConditions<T> for Always {
-	fn check(t: &T) -> bool {
+impl<T> PreConditions<T> for Always {
+	fn check(_t: &T) -> bool {
 		true
 	}
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct Never;
-impl PreConditions<T> for Never {
-	fn check(t: &T) -> bool {
+impl<T> PreConditions<T> for Never {
+	fn check(_t: &T) -> bool {
 		false
 	}
 }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -86,3 +86,24 @@ impl<T> Handler<T> for Tuple {
 		Ok(())
 	}
 }
+
+#[impl_for_tuples(30)]
+pub trait PreConditions<T> {
+	fn check(t: &T) -> bool;
+}
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+pub struct Always;
+impl PreConditions<T> for Always {
+	fn check(t: &T) -> bool {
+		true
+	}
+}
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+pub struct Never;
+impl PreConditions<T> for Never {
+	fn check(t: &T) -> bool {
+		false
+	}
+}

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -87,9 +87,15 @@ impl<T> Handler<T> for Tuple {
 	}
 }
 
-#[impl_for_tuples(30)]
 pub trait PreConditions<T> {
 	fn check(t: &T) -> bool;
+}
+
+#[impl_for_tuples(10)]
+impl<T> PreConditions<T> for Tuple {
+	fn check(t: &T) -> bool {
+		for_tuples!( #( Tuple::check(t) )&* )
+	}
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]


### PR DESCRIPTION
This is a proposal to allow runtimes to run arbitrary checks on a given `sender, receiver, currency_id, amount` combination for normal transfers. 

The current approach only checks if the preconditions for a transfer are met when using the public API. I.e. only for normal users. 
The trait interfaces of Multicurrency, Fungibles, etc are not checked. I am not sure if this is generally wanted or not. Substrate tends to leave traits pretty much permissionless.

Happy for feedback and a temperature check how the acceptance of this is.