### PR TITLE
Girazoki fix index in transfer multicurrencies

### DIFF
--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -506,10 +506,10 @@ pub mod module {
 
 			// Push contains saturated addition, so we should be able to use it safely
 			let mut assets = MultiAssets::new();
-			assets.push(asset);
+			assets.push(asset.clone());
 			assets.push(fee.clone());
 
-			Self::do_transfer_multiassets(who, assets, fee, dest, dest_weight, false)?;
+			Self::do_transfer_multiassets(who.clone(), assets, fee.clone(), dest.clone(), dest_weight, false)?;
 
 			Self::deposit_event(Event::<T>::TransferredMultiAssetWithFee {
 				sender: who,

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -511,7 +511,12 @@ pub mod module {
 
 			Self::do_transfer_multiassets(who, assets, fee, dest, dest_weight, false)?;
 
-			Self::deposit_event(Event::<T>::TransferredMultiAssetWithFee(who, asset, fee, dest));
+			Self::deposit_event(Event::<T>::TransferredMultiAssetWithFee {
+				sender: who,
+				asset,
+				fee,
+				dest,
+			});
 
 			Ok(())
 		}

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -511,6 +511,8 @@ pub mod module {
 
 			Self::do_transfer_multiassets(who, assets, fee, dest, dest_weight, false)?;
 
+			Self::deposit_event(Event::<T>::TransferredMultiAssetWithFee(who, asset, fee, dest));
+
 			Ok(())
 		}
 

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -354,6 +354,52 @@ fn send_sibling_asset_to_reserve_sibling_with_distinc_fee() {
 	ParaA::execute_with(|| {
 		assert_ok!(ParaXTokens::transfer_multicurrencies(
 			Some(ALICE).into(),
+			vec![(CurrencyId::B1, 50), (CurrencyId::B, 450)],
+			0,
+			Box::new(
+				(
+					Parent,
+					Parachain(2),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
+			40,
+		));
+
+		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 550);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::B1, &ALICE), 950);
+	});
+
+	// It should use 40 for weight, so 450 B and 10 B1 should reach destination
+	ParaB::execute_with(|| {
+		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &sibling_a_account()), 550);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::B1, &sibling_a_account()), 950);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &BOB), 450);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::B1, &BOB), 10);
+	});
+}
+
+#[test]
+fn send_sibling_asset_to_reserve_sibling_with_distinc_fee_index_works() {
+	TestNet::reset();
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::B, &ALICE, 1_000));
+		assert_ok!(ParaTokens::deposit(CurrencyId::B1, &ALICE, 1_000));
+	});
+
+	ParaB::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::B, &sibling_a_account(), 1_000));
+		assert_ok!(ParaTokens::deposit(CurrencyId::B1, &sibling_a_account(), 1_000));
+	});
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaXTokens::transfer_multicurrencies(
+			Some(ALICE).into(),
 			vec![(CurrencyId::B, 450), (CurrencyId::B1, 50)],
 			1,
 			Box::new(


### PR DESCRIPTION
Gets the fee item before the multicurrencies vec is converted to a MultiAssets item. The reason is that in the conversion to MultiAssets, the vector is sorted and the index might no longer match what the users specifies.

It also adds a removed event from last refactor