### PR TITLE
`here()` should be a self-reserve

### DIFF
--- a/traits/src/location.rs
+++ b/traits/src/location.rs
@@ -22,6 +22,8 @@ impl Parse for MultiLocation {
 			(1, _) => Some(MultiLocation::parent()),
 			// children parachain
 			(0, Some(Parachain(id))) => Some(MultiLocation::new(0, X1(Parachain(*id)))),
+			// self reserve
+			(0, None) => Some(MultiLocation::here()),
 			_ => None,
 		}
 	}


### PR DESCRIPTION
Under the new re-anchoring logic, it is advised to use `here()` to be the sender location, in this case, ORML should allow `here()` to be a self-reserve. 

The related test code on Manta:
https://github.com/Manta-Network/Manta/blob/xcm-v4/runtime/dolphin/tests/xcm_tests.rs#L286 