### PR TITLE
add parachain c

### DIFF
--- a/xtokens/src/mock/mod.rs
+++ b/xtokens/src/mock/mod.rs
@@ -30,7 +30,7 @@ pub enum CurrencyId {
 	/// Parachain B B1 token
 	B1,
 	/// Parachain C native token
-	C
+	C,
 }
 
 pub struct CurrencyIdConvert;

--- a/xtokens/src/mock/mod.rs
+++ b/xtokens/src/mock/mod.rs
@@ -29,6 +29,8 @@ pub enum CurrencyId {
 	B,
 	/// Parachain B B1 token
 	B1,
+	/// Parachain C native token
+	C
 }
 
 pub struct CurrencyIdConvert;
@@ -40,6 +42,7 @@ impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
 			CurrencyId::A1 => Some((Parent, Parachain(1), GeneralKey("A1".into())).into()),
 			CurrencyId::B => Some((Parent, Parachain(2), GeneralKey("B".into())).into()),
 			CurrencyId::B1 => Some((Parent, Parachain(2), GeneralKey("B1".into())).into()),
+			CurrencyId::C => Some((Parent, Parachain(3)).into()),
 		}
 	}
 }
@@ -58,6 +61,7 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 				X2(Parachain(1), GeneralKey(k)) if k == a1 => Some(CurrencyId::A1),
 				X2(Parachain(2), GeneralKey(k)) if k == b => Some(CurrencyId::B),
 				X2(Parachain(2), GeneralKey(k)) if k == b1 => Some(CurrencyId::B1),
+				X1(Parachain(3)) => Some(CurrencyId::C),
 				_ => None,
 			},
 			MultiLocation { parents, interior } if parents == 0 => match interior {
@@ -65,6 +69,7 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 				X1(GeneralKey(k)) if k == b => Some(CurrencyId::B),
 				X1(GeneralKey(k)) if k == a1 => Some(CurrencyId::A1),
 				X1(GeneralKey(k)) if k == b1 => Some(CurrencyId::B1),
+				Here => Some(CurrencyId::C),
 				_ => None,
 			},
 			_ => None,

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -296,6 +296,70 @@ fn send_sibling_asset_to_reserve_sibling() {
 }
 
 #[test]
+fn send_sibling_asset_to_reserve_sibling_c() {
+	TestNet::reset();
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::C, &ALICE, 1_000));
+	});
+
+	ParaC::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::C, &sibling_a_account(), 1_000));
+	});
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaXTokens::transfer(
+			Some(ALICE).into(),
+			CurrencyId::C,
+			500,
+			Box::new(
+				(
+					Parent,
+					Parachain(3),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
+			40,
+		));
+
+		assert_eq!(ParaTokens::free_balance(CurrencyId::C, &ALICE), 500);
+	});
+
+	ParaC::execute_with(|| {
+		assert_eq!(ParaTokens::free_balance(CurrencyId::C, &sibling_a_account()), 500);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::C, &BOB), 460);
+
+		assert_ok!(ParaXTokens::transfer(
+			Some(BOB).into(),
+			CurrencyId::C,
+			100,
+			Box::new(
+				(
+					Parent,
+					Parachain(1),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: ALICE.into(),
+					},
+				)
+					.into()
+			),
+			40,
+		));
+		assert_eq!(ParaTokens::free_balance(CurrencyId::C, &BOB), 360);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::C, &sibling_a_account()), 600);
+	});
+
+	ParaA::execute_with(|| {
+		assert_eq!(ParaTokens::free_balance(CurrencyId::C, &ALICE), 560);
+	});
+}
+
+#[test]
 fn send_sibling_asset_to_reserve_sibling_with_fee() {
 	TestNet::reset();
 


### PR DESCRIPTION
some parachain may not use `GeneralKey` as its token, but use just its parachain, i.e. PHA:

https://github.com/AcalaNetwork/Acala/blob/d92b2db7e384ebf24dafc89d7cc0e04ee4724435/runtime/karura/src/lib.rs#L1811-L1812

```rust
// Phala Native token
Token(PHA) => Some(MultiLocation::new(1, X1(Parachain(parachains::phala::ID)))),
```

this PR add parachain c, and use parachain(3) to represent its token.