### PR TITLE
Girazoki configurable reserve provider

### DIFF
--- a/traits/src/location.rs
+++ b/traits/src/location.rs
@@ -65,16 +65,10 @@ pub struct RelativeReserveProvider;
 impl Reserve for RelativeReserveProvider {
 	fn reserve(asset: &MultiAsset) -> Option<MultiLocation> {
 		if let Concrete(location) = &asset.id {
-			match (location.parents, location.first_interior()) {
-				// sibling parachain
-				(1, Some(Parachain(id))) => Some(MultiLocation::new(1, X1(Parachain(*id)))),
-				// parent
-				(1, _) => Some(MultiLocation::parent()),
-				// children parachain
-				(0, Some(Parachain(id))) => Some(MultiLocation::new(0, X1(Parachain(*id)))),
-				// All asset that is not a children parachain is a self reserved asset
-				(0, _) => Some(MultiLocation::here()),
-				_ => None,
+			if location.parents == 0 && !is_chain_junction(location.first_interior()) {
+				Some(MultiLocation::here())
+			} else {
+				location.chain_part()
 			}
 		} else {
 			None

--- a/traits/src/location.rs
+++ b/traits/src/location.rs
@@ -42,13 +42,14 @@ impl Parse for MultiLocation {
 
 pub trait Reserve {
 	/// Returns assets reserve location.
-	fn reserve(asset: MultiAsset) -> Option<MultiLocation>;
+	fn reserve(asset: &MultiAsset) -> Option<MultiLocation>;
 }
 
+// Provide reserve in absolute path view
 pub struct AbsoluteReserveProvider;
 
 impl Reserve for AbsoluteReserveProvider {
-	fn reserve(asset: MultiAsset) -> Option<MultiLocation> {
+	fn reserve(asset: &MultiAsset) -> Option<MultiLocation> {
 		if let Concrete(location) = &asset.id {
 			location.chain_part()
 		} else {
@@ -81,7 +82,7 @@ mod tests {
 	#[test]
 	fn parent_as_reserve_chain() {
 		assert_eq!(
-			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(1, X1(GENERAL_INDEX)))),
+			AbsoluteReserveProvider::reserve(&concrete_fungible(MultiLocation::new(1, X1(GENERAL_INDEX)))),
 			Some(MultiLocation::parent())
 		);
 	}
@@ -89,7 +90,7 @@ mod tests {
 	#[test]
 	fn sibling_parachain_as_reserve_chain() {
 		assert_eq!(
-			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(1, X2(PARACHAIN, GENERAL_INDEX)))),
+			AbsoluteReserveProvider::reserve(&concrete_fungible(MultiLocation::new(1, X2(PARACHAIN, GENERAL_INDEX)))),
 			Some(MultiLocation::new(1, X1(PARACHAIN)))
 		);
 	}
@@ -97,7 +98,7 @@ mod tests {
 	#[test]
 	fn child_parachain_as_reserve_chain() {
 		assert_eq!(
-			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(0, X2(PARACHAIN, GENERAL_INDEX)))),
+			AbsoluteReserveProvider::reserve(&concrete_fungible(MultiLocation::new(0, X2(PARACHAIN, GENERAL_INDEX)))),
 			Some(PARACHAIN.into())
 		);
 	}
@@ -105,7 +106,7 @@ mod tests {
 	#[test]
 	fn no_reserve_chain() {
 		assert_eq!(
-			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(0, X1(GeneralKey("DOT".into()))))),
+			AbsoluteReserveProvider::reserve(&concrete_fungible(MultiLocation::new(0, X1(GeneralKey("DOT".into()))))),
 			None
 		);
 	}

--- a/traits/src/location.rs
+++ b/traits/src/location.rs
@@ -42,12 +42,14 @@ impl Parse for MultiLocation {
 
 pub trait Reserve {
 	/// Returns assets reserve location.
-	fn reserve(&self) -> Option<MultiLocation>;
+	fn reserve(asset: MultiAsset) -> Option<MultiLocation>;
 }
 
-impl Reserve for MultiAsset {
-	fn reserve(&self) -> Option<MultiLocation> {
-		if let Concrete(location) = &self.id {
+pub struct AbsoluteReserveProvider;
+
+impl Reserve for AbsoluteReserveProvider {
+	fn reserve(asset: MultiAsset) -> Option<MultiLocation> {
+		if let Concrete(location) = &asset.id {
 			location.chain_part()
 		} else {
 			None
@@ -79,7 +81,7 @@ mod tests {
 	#[test]
 	fn parent_as_reserve_chain() {
 		assert_eq!(
-			concrete_fungible(MultiLocation::new(1, X1(GENERAL_INDEX))).reserve(),
+			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(1, X1(GENERAL_INDEX)))),
 			Some(MultiLocation::parent())
 		);
 	}
@@ -87,7 +89,7 @@ mod tests {
 	#[test]
 	fn sibling_parachain_as_reserve_chain() {
 		assert_eq!(
-			concrete_fungible(MultiLocation::new(1, X2(PARACHAIN, GENERAL_INDEX))).reserve(),
+			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(1, X2(PARACHAIN, GENERAL_INDEX)))),
 			Some(MultiLocation::new(1, X1(PARACHAIN)))
 		);
 	}
@@ -95,7 +97,7 @@ mod tests {
 	#[test]
 	fn child_parachain_as_reserve_chain() {
 		assert_eq!(
-			concrete_fungible(MultiLocation::new(0, X2(PARACHAIN, GENERAL_INDEX))).reserve(),
+			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(0, X2(PARACHAIN, GENERAL_INDEX)))),
 			Some(PARACHAIN.into())
 		);
 	}
@@ -103,7 +105,7 @@ mod tests {
 	#[test]
 	fn no_reserve_chain() {
 		assert_eq!(
-			concrete_fungible(MultiLocation::new(0, X1(GeneralKey("DOT".into())))).reserve(),
+			AbsoluteReserveProvider::reserve(concrete_fungible(MultiLocation::new(0, X1(GeneralKey("DOT".into()))))),
 			None
 		);
 	}

--- a/xcm-support/src/lib.rs
+++ b/xcm-support/src/lib.rs
@@ -44,10 +44,13 @@ where
 
 /// A `FilterAssetLocation` implementation. Filters multi native assets whose
 /// reserve is same with `origin`.
-pub struct MultiNativeAsset;
-impl FilterAssetLocation for MultiNativeAsset {
+pub struct MultiNativeAsset<ReserveProvider>(PhantomData<ReserveProvider>);
+impl<ReserveProvider> FilterAssetLocation for MultiNativeAsset<ReserveProvider>
+where
+	ReserveProvider: Reserve,
+{
 	fn filter_asset_location(asset: &MultiAsset, origin: &MultiLocation) -> bool {
-		if let Some(ref reserve) = asset.reserve() {
+		if let Some(ref reserve) = ReserveProvider::reserve(asset.clone()) {
 			if reserve == origin {
 				return true;
 			}

--- a/xcm-support/src/lib.rs
+++ b/xcm-support/src/lib.rs
@@ -50,7 +50,7 @@ where
 	ReserveProvider: Reserve,
 {
 	fn filter_asset_location(asset: &MultiAsset, origin: &MultiLocation) -> bool {
-		if let Some(ref reserve) = ReserveProvider::reserve(asset.clone()) {
+		if let Some(ref reserve) = ReserveProvider::reserve(asset) {
 			if reserve == origin {
 				return true;
 			}

--- a/xcm-support/src/tests.rs
+++ b/xcm-support/src/tests.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-use orml_traits::{location::RelativeLocations, ConcreteFungibleAsset};
+use orml_traits::{location::AbsoluteReserveProvider, location::RelativeLocations, ConcreteFungibleAsset};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum TestCurrencyId {
@@ -82,18 +82,18 @@ fn is_native_concrete_does_not_matches_non_native_currencies() {
 
 #[test]
 fn multi_native_asset() {
-	assert!(MultiNativeAsset::filter_asset_location(
+	assert!(MultiNativeAsset::<AbsoluteReserveProvider>::filter_asset_location(
 		&MultiAsset {
 			fun: Fungible(10),
 			id: Concrete(MultiLocation::parent())
 		},
 		&Parent.into()
 	));
-	assert!(MultiNativeAsset::filter_asset_location(
+	assert!(MultiNativeAsset::<AbsoluteReserveProvider>::filter_asset_location(
 		&MultiAsset::sibling_parachain_asset(1, "TokenA".into(), 100),
 		&MultiLocation::new(1, X1(Parachain(1))),
 	));
-	assert!(!MultiNativeAsset::filter_asset_location(
+	assert!(!MultiNativeAsset::<AbsoluteReserveProvider>::filter_asset_location(
 		&MultiAsset::sibling_parachain_asset(1, "TokenA".into(), 100),
 		&MultiLocation::parent(),
 	));

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -863,7 +863,7 @@ pub mod module {
 				0
 			};
 			let asset = assets.get(reserve_idx);
-			asset.and_then(|a| T::ReserveProvider::reserve(a))
+			asset.and_then(T::ReserveProvider::reserve)
 		}
 	}
 

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -480,7 +480,7 @@ pub mod module {
 					Error::<T>::InvalidAsset
 				);
 				ensure!(
-					T::ReserveProvider::reserve(fee) == T::ReserveProvider::reserve(asset),
+					T::ReserveProvider::reserve(&fee) == T::ReserveProvider::reserve(asset),
 					Error::<T>::DistinctReserveForAssetAndFee
 				);
 			}

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -478,7 +478,7 @@ pub mod module {
 					Error::<T>::InvalidAsset
 				);
 				ensure!(
-					T::ReserveProvider::reserve(fee.clone()) == T::ReserveProvider::reserve(asset.clone()),
+					T::ReserveProvider::reserve(&fee) == T::ReserveProvider::reserve(&asset),
 					Error::<T>::DistinctReserveForAssetAndFee
 				);
 			}
@@ -656,7 +656,7 @@ pub mod module {
 			let self_location = T::SelfLocation::get();
 			ensure!(dest != self_location, Error::<T>::NotCrossChainTransfer);
 
-			let reserve = T::ReserveProvider::reserve(asset.clone()).ok_or(Error::<T>::AssetHasNoReserve)?;
+			let reserve = T::ReserveProvider::reserve(&asset).ok_or(Error::<T>::AssetHasNoReserve)?;
 			let transfer_kind = if reserve == self_location {
 				SelfReserveAsset
 			} else if reserve == dest {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -103,6 +103,8 @@ pub mod module {
 		/// single helper extrinsic.
 		type MaxAssetsForTransfer: Get<usize>;
 
+		/// The way to retreave the reserve of a MultiAsset. This can be configured
+		/// to accept absolute or relative paths for self tokens
 		type ReserveProvider: Reserve;
 	}
 

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -480,7 +480,7 @@ pub mod module {
 					Error::<T>::InvalidAsset
 				);
 				ensure!(
-					T::ReserveProvider::reserve(&fee) == T::ReserveProvider::reserve(&asset),
+					T::ReserveProvider::reserve(fee) == T::ReserveProvider::reserve(asset),
 					Error::<T>::DistinctReserveForAssetAndFee
 				);
 			}
@@ -658,7 +658,7 @@ pub mod module {
 			let self_location = T::SelfLocation::get();
 			ensure!(dest != self_location, Error::<T>::NotCrossChainTransfer);
 
-			let reserve = T::ReserveProvider::reserve(&asset).ok_or(Error::<T>::AssetHasNoReserve)?;
+			let reserve = T::ReserveProvider::reserve(asset).ok_or(Error::<T>::AssetHasNoReserve)?;
 			let transfer_kind = if reserve == self_location {
 				SelfReserveAsset
 			} else if reserve == dest {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -102,6 +102,8 @@ pub mod module {
 		/// The maximum number of distinct assets allowed to be transferred in a
 		/// single helper extrinsic.
 		type MaxAssetsForTransfer: Get<usize>;
+
+		type ReserveProvider: Reserve;
 	}
 
 	#[pallet::event]
@@ -476,7 +478,7 @@ pub mod module {
 					Error::<T>::InvalidAsset
 				);
 				ensure!(
-					fee.reserve() == asset.reserve(),
+					T::ReserveProvider::reserve(fee.clone()) == T::ReserveProvider::reserve(asset.clone()),
 					Error::<T>::DistinctReserveForAssetAndFee
 				);
 			}
@@ -654,7 +656,7 @@ pub mod module {
 			let self_location = T::SelfLocation::get();
 			ensure!(dest != self_location, Error::<T>::NotCrossChainTransfer);
 
-			let reserve = asset.reserve().ok_or(Error::<T>::AssetHasNoReserve)?;
+			let reserve = T::ReserveProvider::reserve(asset.clone()).ok_or(Error::<T>::AssetHasNoReserve)?;
 			let transfer_kind = if reserve == self_location {
 				SelfReserveAsset
 			} else if reserve == dest {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -103,8 +103,8 @@ pub mod module {
 		/// single helper extrinsic.
 		type MaxAssetsForTransfer: Get<usize>;
 
-		/// The way to retreave the reserve of a MultiAsset. This can be configured
-		/// to accept absolute or relative paths for self tokens
+		/// The way to retreave the reserve of a MultiAsset. This can be
+		/// configured to accept absolute or relative paths for self tokens
 		type ReserveProvider: Reserve;
 	}
 

--- a/xtokens/src/mock/mod.rs
+++ b/xtokens/src/mock/mod.rs
@@ -11,6 +11,7 @@ use sp_runtime::AccountId32;
 use xcm_simulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain};
 
 pub mod para;
+pub mod para_relative_view;
 pub mod relay;
 
 pub const ALICE: AccountId32 = AccountId32::new([0u8; 32]);
@@ -29,6 +30,8 @@ pub enum CurrencyId {
 	B,
 	/// Parachain B B1 token
 	B1,
+	/// Parachain D token
+	D,
 }
 
 pub struct CurrencyIdConvert;
@@ -40,6 +43,7 @@ impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
 			CurrencyId::A1 => Some((Parent, Parachain(1), GeneralKey("A1".into())).into()),
 			CurrencyId::B => Some((Parent, Parachain(2), GeneralKey("B".into())).into()),
 			CurrencyId::B1 => Some((Parent, Parachain(2), GeneralKey("B1".into())).into()),
+			CurrencyId::D => Some((Parent, Parachain(4), GeneralKey("D".into())).into()),
 		}
 	}
 }
@@ -49,6 +53,8 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 		let a1: Vec<u8> = "A1".into();
 		let b: Vec<u8> = "B".into();
 		let b1: Vec<u8> = "B1".into();
+		let d: Vec<u8> = "D".into();
+
 		if l == MultiLocation::parent() {
 			return Some(CurrencyId::R);
 		}
@@ -58,6 +64,7 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 				X2(Parachain(1), GeneralKey(k)) if k == a1 => Some(CurrencyId::A1),
 				X2(Parachain(2), GeneralKey(k)) if k == b => Some(CurrencyId::B),
 				X2(Parachain(2), GeneralKey(k)) if k == b1 => Some(CurrencyId::B1),
+				X2(Parachain(4), GeneralKey(k)) if k == d => Some(CurrencyId::D),
 				_ => None,
 			},
 			MultiLocation { parents, interior } if parents == 0 => match interior {
@@ -65,6 +72,7 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 				X1(GeneralKey(k)) if k == b => Some(CurrencyId::B),
 				X1(GeneralKey(k)) if k == a1 => Some(CurrencyId::A1),
 				X1(GeneralKey(k)) if k == b1 => Some(CurrencyId::B1),
+				X1(GeneralKey(k)) if k == d => Some(CurrencyId::D),
 				_ => None,
 			},
 			_ => None,
@@ -115,6 +123,17 @@ decl_test_parachain! {
 	}
 }
 
+// This parachain is identical to the others but using relative view for self
+// tokens
+decl_test_parachain! {
+	pub struct ParaD {
+		Runtime = para_relative_view::Runtime,
+		XcmpMessageHandler = para::XcmpQueue,
+		DmpMessageHandler = para::DmpQueue,
+		new_ext = para_ext(4),
+	}
+}
+
 decl_test_relay_chain! {
 	pub struct Relay {
 		Runtime = relay::Runtime,
@@ -130,6 +149,7 @@ decl_test_network! {
 			(1, ParaA),
 			(2, ParaB),
 			(3, ParaC),
+			(4, ParaD),
 		],
 	}
 }
@@ -137,6 +157,9 @@ decl_test_network! {
 pub type RelayBalances = pallet_balances::Pallet<relay::Runtime>;
 pub type ParaTokens = orml_tokens::Pallet<para::Runtime>;
 pub type ParaXTokens = orml_xtokens::Pallet<para::Runtime>;
+
+pub type ParaRelativeTokens = orml_tokens::Pallet<para_relative_view::Runtime>;
+pub type ParaRelativeXTokens = orml_xtokens::Pallet<para_relative_view::Runtime>;
 
 pub fn para_ext(para_id: u32) -> TestExternalities {
 	use para::{Runtime, System};

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -193,7 +193,7 @@ impl Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = XcmOriginToCallOrigin;
-	type IsReserve = MultiNativeAsset;
+	type IsReserve = MultiNativeAsset<orml_traits::location::AbsoluteReserveProvider>;
 	type IsTeleporter = ();
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
@@ -284,6 +284,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
+	type ReserveProvider = orml_traits::location::AbsoluteReserveProvider;
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -25,7 +25,7 @@ use xcm_builder::{
 };
 use xcm_executor::{traits::WeightTrader, Assets, Config, XcmExecutor};
 
-use orml_traits::parameter_type_with_key;
+use orml_traits::{parameter_type_with_key, location::AbsoluteReserveProvider};
 use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 
 pub type AccountId = AccountId32;
@@ -193,7 +193,7 @@ impl Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = XcmOriginToCallOrigin;
-	type IsReserve = MultiNativeAsset<orml_traits::location::AbsoluteReserveProvider>;
+	type IsReserve = MultiNativeAsset<AbsoluteReserveProvider>;
 	type IsTeleporter = ();
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
@@ -284,7 +284,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = orml_traits::location::AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteReserveProvider;
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -25,7 +25,7 @@ use xcm_builder::{
 };
 use xcm_executor::{traits::WeightTrader, Assets, Config, XcmExecutor};
 
-use orml_traits::{parameter_type_with_key, location::AbsoluteReserveProvider};
+use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
 use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 
 pub type AccountId = AccountId32;

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -1,0 +1,381 @@
+use super::{Amount, Balance, CurrencyId, CurrencyIdConvert, ParachainXcmRouter};
+use crate as orml_xtokens;
+
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{Everything, Nothing},
+	weights::{constants::WEIGHT_PER_SECOND, Weight},
+};
+use frame_system::EnsureRoot;
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{Convert, IdentityLookup, Zero},
+	AccountId32,
+};
+
+use cumulus_primitives_core::{ChannelStatus, GetChannelInfo, ParaId};
+use pallet_xcm::XcmPassthrough;
+use polkadot_parachain::primitives::Sibling;
+use xcm::latest::prelude::*;
+use xcm_builder::{
+	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds, LocationInverter,
+	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+};
+use xcm_executor::{traits::WeightTrader, Assets, Config, XcmExecutor};
+
+use orml_traits::{
+	location::{AbsoluteReserveProvider, RelativeReserveProvider},
+	parameter_type_with_key,
+};
+use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
+
+pub type AccountId = AccountId32;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+}
+
+impl frame_system::Config for Runtime {
+	type Origin = Origin;
+	type Call = Call;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = ::sp_runtime::traits::BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type DbWeight = ();
+	type BaseCallFilter = Everything;
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+parameter_types! {
+	pub ExistentialDeposit: Balance = 1;
+	pub const MaxLocks: u32 = 50;
+	pub const MaxReserves: u32 = 50;
+}
+
+impl pallet_balances::Config for Runtime {
+	type MaxLocks = MaxLocks;
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+}
+
+parameter_type_with_key! {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+		Default::default()
+	};
+}
+
+impl orml_tokens::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type Amount = Amount;
+	type CurrencyId = CurrencyId;
+	type WeightInfo = ();
+	type ExistentialDeposits = ExistentialDeposits;
+	type OnDust = ();
+	type MaxLocks = MaxLocks;
+	type DustRemovalWhitelist = Everything;
+}
+
+parameter_types! {
+	pub const ReservedXcmpWeight: Weight = WEIGHT_PER_SECOND / 4;
+	pub const ReservedDmpWeight: Weight = WEIGHT_PER_SECOND / 4;
+}
+
+impl parachain_info::Config for Runtime {}
+
+parameter_types! {
+	pub const RelayLocation: MultiLocation = MultiLocation::parent();
+	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
+	pub RelayChainOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
+	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+}
+
+pub type LocationToAccountId = (
+	ParentIsPreset<AccountId>,
+	SiblingParachainConvertsVia<Sibling, AccountId>,
+	AccountId32Aliases<RelayNetwork, AccountId>,
+);
+
+pub type XcmOriginToCallOrigin = (
+	SovereignSignedViaLocation<LocationToAccountId, Origin>,
+	RelayChainAsNative<RelayChainOrigin, Origin>,
+	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, Origin>,
+	SignedAccountId32AsNative<RelayNetwork, Origin>,
+	XcmPassthrough<Origin>,
+);
+
+parameter_types! {
+	pub const UnitWeightCost: Weight = 10;
+	pub const MaxInstructions: u32 = 100;
+}
+
+pub type LocalAssetTransactor = MultiCurrencyAdapter<
+	Tokens,
+	(),
+	IsNativeConcrete<CurrencyId, CurrencyIdConvert>,
+	AccountId,
+	LocationToAccountId,
+	CurrencyId,
+	CurrencyIdConvert,
+	(),
+>;
+
+pub type XcmRouter = ParachainXcmRouter<ParachainInfo>;
+pub type Barrier = (TakeWeightCredit, AllowTopLevelPaidExecutionFrom<Everything>);
+
+/// A trader who believes all tokens are created equal to "weight" of any chain,
+/// which is not true, but good enough to mock the fee payment of XCM execution.
+///
+/// This mock will always trade `n` amount of weight to `n` amount of tokens.
+pub struct AllTokensAreCreatedEqualToWeight(MultiLocation);
+impl WeightTrader for AllTokensAreCreatedEqualToWeight {
+	fn new() -> Self {
+		Self(MultiLocation::parent())
+	}
+
+	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+		let asset_id = payment
+			.fungible
+			.iter()
+			.next()
+			.expect("Payment must be something; qed")
+			.0;
+		let required = MultiAsset {
+			id: asset_id.clone(),
+			fun: Fungible(weight as u128),
+		};
+
+		if let MultiAsset {
+			fun: _,
+			id: Concrete(ref id),
+		} = &required
+		{
+			self.0 = id.clone();
+		}
+
+		let unused = payment.checked_sub(required).map_err(|_| XcmError::TooExpensive)?;
+		Ok(unused)
+	}
+
+	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
+		if weight.is_zero() {
+			None
+		} else {
+			Some((self.0.clone(), weight as u128).into())
+		}
+	}
+}
+
+pub struct XcmConfig;
+impl Config for XcmConfig {
+	type Call = Call;
+	type XcmSender = XcmRouter;
+	type AssetTransactor = LocalAssetTransactor;
+	type OriginConverter = XcmOriginToCallOrigin;
+	type IsReserve = MultiNativeAsset<AbsoluteReserveProvider>;
+	type IsTeleporter = ();
+	type LocationInverter = LocationInverter<Ancestry>;
+	type Barrier = Barrier;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type Trader = AllTokensAreCreatedEqualToWeight;
+	type ResponseHandler = ();
+	type AssetTrap = PolkadotXcm;
+	type AssetClaims = PolkadotXcm;
+	type SubscriptionService = PolkadotXcm;
+}
+
+pub struct ChannelInfo;
+impl GetChannelInfo for ChannelInfo {
+	fn get_channel_status(_id: ParaId) -> ChannelStatus {
+		ChannelStatus::Ready(10, 10)
+	}
+	fn get_channel_max(_id: ParaId) -> Option<usize> {
+		Some(usize::max_value())
+	}
+}
+
+impl cumulus_pallet_xcmp_queue::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type ChannelInfo = ChannelInfo;
+	type VersionWrapper = ();
+	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ControllerOrigin = EnsureRoot<AccountId>;
+	type ControllerOriginConverter = XcmOriginToCallOrigin;
+}
+
+impl cumulus_pallet_dmp_queue::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+}
+
+impl cumulus_pallet_xcm::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, RelayNetwork>;
+
+impl pallet_xcm::Config for Runtime {
+	type Event = Event;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmExecuteFilter = Everything;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type XcmTeleportFilter = Nothing;
+	type XcmReserveTransferFilter = Everything;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type Origin = Origin;
+	type Call = Call;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+}
+
+pub struct AccountIdToMultiLocation;
+impl Convert<AccountId, MultiLocation> for AccountIdToMultiLocation {
+	fn convert(account: AccountId) -> MultiLocation {
+		X1(Junction::AccountId32 {
+			network: NetworkId::Any,
+			id: account.into(),
+		})
+		.into()
+	}
+}
+
+pub struct RelativeCurrencyIdConvert;
+impl Convert<CurrencyId, Option<MultiLocation>> for RelativeCurrencyIdConvert {
+	fn convert(id: CurrencyId) -> Option<MultiLocation> {
+		match id {
+			CurrencyId::R => Some(Parent.into()),
+			CurrencyId::A => Some((Parent, Parachain(1), GeneralKey("A".into())).into()),
+			CurrencyId::A1 => Some((Parent, Parachain(1), GeneralKey("A1".into())).into()),
+			CurrencyId::B => Some((Parent, Parachain(2), GeneralKey("B".into())).into()),
+			CurrencyId::B1 => Some((Parent, Parachain(2), GeneralKey("B1".into())).into()),
+			CurrencyId::D => Some(GeneralKey("D".into()).into()),
+		}
+	}
+}
+impl Convert<MultiLocation, Option<CurrencyId>> for RelativeCurrencyIdConvert {
+	fn convert(l: MultiLocation) -> Option<CurrencyId> {
+		let a: Vec<u8> = "A".into();
+		let a1: Vec<u8> = "A1".into();
+		let b: Vec<u8> = "B".into();
+		let b1: Vec<u8> = "B1".into();
+		let d: Vec<u8> = "D".into();
+
+		let self_para_id: u32 = ParachainInfo::parachain_id().into();
+		if l == MultiLocation::parent() {
+			return Some(CurrencyId::R);
+		}
+		match l {
+			MultiLocation { parents, interior } if parents == 1 => match interior {
+				X2(Parachain(1), GeneralKey(k)) if k == a => Some(CurrencyId::A),
+				X2(Parachain(1), GeneralKey(k)) if k == a1 => Some(CurrencyId::A1),
+				X2(Parachain(2), GeneralKey(k)) if k == b => Some(CurrencyId::B),
+				X2(Parachain(2), GeneralKey(k)) if k == b1 => Some(CurrencyId::B1),
+				X2(Parachain(para_id), GeneralKey(k)) if k == d && para_id == self_para_id => Some(CurrencyId::D),
+				_ => None,
+			},
+			MultiLocation { parents, interior } if parents == 0 => match interior {
+				X1(GeneralKey(k)) if k == a => Some(CurrencyId::A),
+				X1(GeneralKey(k)) if k == b => Some(CurrencyId::B),
+				X1(GeneralKey(k)) if k == a1 => Some(CurrencyId::A1),
+				X1(GeneralKey(k)) if k == b1 => Some(CurrencyId::B1),
+				X1(GeneralKey(k)) if k == d => Some(CurrencyId::D),
+				_ => None,
+			},
+			_ => None,
+		}
+	}
+}
+impl Convert<MultiAsset, Option<CurrencyId>> for RelativeCurrencyIdConvert {
+	fn convert(a: MultiAsset) -> Option<CurrencyId> {
+		if let MultiAsset {
+			fun: Fungible(_),
+			id: Concrete(id),
+		} = a
+		{
+			Self::convert(id)
+		} else {
+			Option::None
+		}
+	}
+}
+
+parameter_types! {
+	pub SelfLocation: MultiLocation = MultiLocation::here();
+	pub const BaseXcmWeight: Weight = 100_000_000;
+	pub const MaxAssetsForTransfer: usize = 2;
+}
+
+impl orml_xtokens::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type CurrencyId = CurrencyId;
+	type CurrencyIdConvert = RelativeCurrencyIdConvert;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation;
+	type SelfLocation = SelfLocation;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type BaseXcmWeight = BaseXcmWeight;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type MaxAssetsForTransfer = MaxAssetsForTransfer;
+	type ReserveProvider = RelativeReserveProvider;
+}
+
+impl orml_xcm::Config for Runtime {
+	type Event = Event;
+	type SovereignOrigin = EnsureRoot<AccountId>;
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+
+		ParachainInfo: parachain_info::{Pallet, Storage, Config},
+		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
+		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
+		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
+
+		Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
+		XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},
+
+		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
+		OrmlXcm: orml_xcm::{Pallet, Call, Event<T>},
+	}
+);

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -33,6 +33,11 @@ fn sibling_c_account() -> AccountId32 {
 	Sibling::from(3).into_account()
 }
 
+fn sibling_d_account() -> AccountId32 {
+	use sp_runtime::traits::AccountIdConversion;
+	Sibling::from(4).into_account()
+}
+
 // Not used in any unit tests, but it's super helpful for debugging. Let's
 // keep it here.
 #[allow(dead_code)]
@@ -1098,4 +1103,112 @@ fn send_with_zero_amount() {
 	});
 
 	// TODO: should have more tests after https://github.com/paritytech/polkadot/issues/4996
+}
+
+#[test]
+fn send_self_parachain_asset_to_sibling_relative_parachain() {
+	TestNet::reset();
+
+	ParaD::execute_with(|| {
+		assert_ok!(ParaRelativeTokens::deposit(CurrencyId::D, &ALICE, 1_000));
+
+		assert_ok!(ParaRelativeXTokens::transfer(
+			Some(ALICE).into(),
+			CurrencyId::D,
+			500,
+			Box::new(
+				MultiLocation::new(
+					1,
+					X2(
+						Parachain(2),
+						Junction::AccountId32 {
+							network: NetworkId::Any,
+							id: BOB.into(),
+						}
+					)
+				)
+				.into()
+			),
+			40,
+		));
+
+		assert_eq!(ParaRelativeTokens::free_balance(CurrencyId::D, &ALICE), 500);
+		assert_eq!(
+			ParaRelativeTokens::free_balance(CurrencyId::D, &sibling_b_account()),
+			500
+		);
+	});
+
+	ParaB::execute_with(|| {
+		assert_eq!(ParaTokens::free_balance(CurrencyId::D, &BOB), 460);
+	});
+}
+
+#[test]
+fn send_sibling_asset_to_reserve_sibling_with_relative_view() {
+	TestNet::reset();
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::D, &ALICE, 1_000));
+		assert_ok!(ParaTokens::deposit(CurrencyId::A, &sibling_d_account(), 1_000));
+	});
+
+	ParaD::execute_with(|| {
+		assert_ok!(ParaRelativeTokens::deposit(CurrencyId::D, &sibling_a_account(), 1_000));
+		assert_ok!(ParaRelativeTokens::deposit(CurrencyId::A, &BOB, 1_000));
+	});
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaXTokens::transfer(
+			Some(ALICE).into(),
+			CurrencyId::D,
+			500,
+			Box::new(
+				(
+					Parent,
+					Parachain(4),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
+			40,
+		));
+
+		assert_eq!(ParaTokens::free_balance(CurrencyId::D, &ALICE), 500);
+	});
+
+	ParaD::execute_with(|| {
+		assert_eq!(
+			ParaRelativeTokens::free_balance(CurrencyId::D, &sibling_a_account()),
+			500
+		);
+		assert_eq!(ParaRelativeTokens::free_balance(CurrencyId::D, &BOB), 460);
+
+		assert_ok!(ParaRelativeXTokens::transfer(
+			Some(BOB).into(),
+			CurrencyId::A,
+			500,
+			Box::new(
+				(
+					Parent,
+					Parachain(1),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: ALICE.into(),
+					},
+				)
+					.into()
+			),
+			40,
+		));
+		assert_eq!(ParaRelativeTokens::free_balance(CurrencyId::A, &BOB), 500);
+	});
+
+	ParaA::execute_with(|| {
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &sibling_d_account()), 500);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &ALICE), 460);
+	});
 }


### PR DESCRIPTION
This is a proposal to configure the way the reserve part is calculated for a MultiAsset in xtokens. It includes adding an associated type called `ReserveProvider`, that chains can configure the way they prefer. For instance, while Acala might be willing to keep the absolute view for Self Tokens, while other chains can implement this the way they want, e.g., changing it to a relative view.

This is just a proposal that can be dropped in case the suggestion is not well received. I understand that this implies some changes in the runtimes importing xtokens, but minimal changes to the xtokens code/tests itself

