### PR TITLE
Return earlier if the too many currencies

### DIFF
--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -472,6 +472,10 @@ pub mod module {
 			dest: MultiLocation,
 			dest_weight: Weight,
 		) -> DispatchResult {
+			ensure!(
+				assets.len() <= T::MaxAssetsForTransfer::get(),
+				Error::<T>::TooManyAssetsBeingSent
+			);
 			let origin_location = T::AccountIdToMultiLocation::convert(who.clone());
 
 			let mut non_fee_reserve: Option<MultiLocation> = None;

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -435,6 +435,11 @@ pub mod module {
 			dest: MultiLocation,
 			dest_weight: Weight,
 		) -> DispatchResult {
+			ensure!(
+				currencies.len() <= T::MaxAssetsForTransfer::get(),
+				Error::<T>::TooManyAssetsBeingSent
+			);
+
 			let mut assets = MultiAssets::new();
 
 			// Lets grab the fee amount and location first
@@ -467,10 +472,6 @@ pub mod module {
 			dest: MultiLocation,
 			dest_weight: Weight,
 		) -> DispatchResult {
-			ensure!(
-				assets.len() <= T::MaxAssetsForTransfer::get(),
-				Error::<T>::TooManyAssetsBeingSent
-			);
 			let origin_location = T::AccountIdToMultiLocation::convert(who.clone());
 
 			let mut non_fee_reserve: Option<MultiLocation> = None;


### PR DESCRIPTION
This extrinsic should return more early if too many currencies are sent.
It's better to check it before execute the `for` loop: 
https://github.com/open-web3-stack/open-runtime-module-library/blob/master/xtokens/src/lib.rs#L445