### PR TITLE
Add a filter for filtering unsupported `MultiLocation`

### DIFF
--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -94,8 +94,8 @@ pub mod module {
 		/// XCM executor.
 		type XcmExecutor: ExecuteXcm<Self::Call>;
 
-		///
-		type WhiteListingMultiLocations: Contains<MultiLocation>;
+		/// MultiLocation filter
+		type MultiLocationsFilter: Contains<MultiLocation>;
 
 		/// Means of measuring the weight consumed by an XCM message locally.
 		type Weigher: WeightBounds<Self::Call>;
@@ -167,8 +167,8 @@ pub mod module {
 		AssetIndexNonExistent,
 		/// Fee is not enough.
 		FeeNotEnough,
-		/// Not supported location
-		NotInWhiteListLocation,
+		/// Not supported MultiLocation
+		NotSupportedMultiLocation,
 	}
 
 	#[pallet::hooks]
@@ -384,8 +384,8 @@ pub mod module {
 
 			ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
 			ensure!(
-				T::WhiteListingMultiLocations::contains(&location),
-				Error::<T>::NotInWhiteListLocation
+				T::MultiLocationsFilter::contains(&dest),
+				Error::<T>::NotSupportedMultiLocation
 			);
 
 			let asset: MultiAsset = (location, amount.into()).into();
@@ -406,8 +406,8 @@ pub mod module {
 			ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
 			ensure!(!fee.is_zero(), Error::<T>::ZeroFee);
 			ensure!(
-				T::WhiteListingMultiLocations::contains(&location),
-				Error::<T>::NotInWhiteListLocation
+				T::MultiLocationsFilter::contains(&dest),
+				Error::<T>::NotSupportedMultiLocation
 			);
 
 			let asset = (location.clone(), amount.into()).into();
@@ -466,8 +466,8 @@ pub mod module {
 					.ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
 				ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
 				ensure!(
-					T::WhiteListingMultiLocations::contains(&location),
-					Error::<T>::NotInWhiteListLocation
+					T::MultiLocationsFilter::contains(&dest),
+					Error::<T>::NotSupportedMultiLocation
 				);
 
 				// Push contains saturated addition, so we should be able to use it safely

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -52,6 +52,29 @@ enum TransferKind {
 }
 use TransferKind::*;
 
+pub trait WhiteListingMultiLocations<CurrencyId, Balance> {
+	fn get_supported_locations(&self, currency_id: CurrencyId) -> Option<MultiLocation>;
+	fn get_all_supported_locations(&self) -> Option<Vec<MultiLocation>>;
+	fn get_xcm_fee(&self, currency_id: CurrencyId) -> Balance;
+}
+
+impl<CurrencyId, Balance> WhiteListingMultiLocations<CurrencyId, Balance> for ()
+where
+	Balance: Zero,
+{
+	fn get_supported_locations(&self, _: CurrencyId) -> Option<MultiLocation> {
+		None
+	}
+
+	fn get_all_supported_locations(&self) -> Option<Vec<MultiLocation>> {
+		None
+	}
+
+	fn get_xcm_fee(&self, _: CurrencyId) -> Balance {
+		Zero::zero()
+	}
+}
+
 #[frame_support::pallet]
 pub mod module {
 
@@ -85,6 +108,9 @@ pub mod module {
 
 		/// XCM executor.
 		type XcmExecutor: ExecuteXcm<Self::Call>;
+
+		///
+		type WhiteListingMultiLocations: WhiteListingMultiLocations<Self::CurrencyId, Self::Balance>;
 
 		/// Means of measuring the weight consumed by an XCM message locally.
 		type Weigher: WeightBounds<Self::Call>;

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -458,6 +458,10 @@ pub mod module {
 				currencies.len() <= T::MaxAssetsForTransfer::get(),
 				Error::<T>::TooManyAssetsBeingSent
 			);
+			ensure!(
+				T::MultiLocationsFilter::contains(&dest),
+				Error::<T>::NotSupportedMultiLocation
+			);
 
 			let mut assets = MultiAssets::new();
 
@@ -470,10 +474,6 @@ pub mod module {
 				let location: MultiLocation = T::CurrencyIdConvert::convert(currency_id.clone())
 					.ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
 				ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
-				ensure!(
-					T::MultiLocationsFilter::contains(&dest),
-					Error::<T>::NotSupportedMultiLocation
-				);
 
 				// Push contains saturated addition, so we should be able to use it safely
 				assets.push((location, (*amount).into()).into())
@@ -499,6 +499,10 @@ pub mod module {
 			ensure!(
 				assets.len() <= T::MaxAssetsForTransfer::get(),
 				Error::<T>::TooManyAssetsBeingSent
+			);
+			ensure!(
+				T::MultiLocationsFilter::contains(&dest),
+				Error::<T>::NotSupportedMultiLocation
 			);
 			let origin_location = T::AccountIdToMultiLocation::convert(who.clone());
 

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -294,12 +294,13 @@ parameter_types! {
 pub struct WhiteListingMultiLocations;
 impl Contains<MultiLocation> for WhiteListingMultiLocations {
 	fn contains(dest: &MultiLocation) -> bool {
-		if dest.parent_count() != 1 {
+		// Consider children parachain, means parent = 0
+		if dest.parent_count() != 0 && dest.parent_count() != 1 {
 			return false;
 		}
 
 		if let Junctions::X1(Junction::AccountId32 { .. }) = dest.interior() {
-			// parent = 1, and the junctions is the variant X1
+			// parent = 1 or 0, and the junctions is the variant X1
 			// means the asset will be sent to relaychain.
 			true
 		} else {

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -316,7 +316,6 @@ parameter_types! {
 pub struct WhiteListingMultiLocations;
 impl Contains<MultiLocation> for WhiteListingMultiLocations {
 	fn contains(location: &MultiLocation) -> bool {
-		dbg!(&location);
 		SupportedMultiLocations::get().contains(location)
 	}
 }

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -279,6 +279,7 @@ impl orml_xtokens::Config for Runtime {
 	type CurrencyIdConvert = CurrencyIdConvert;
 	type AccountIdToMultiLocation = AccountIdToMultiLocation;
 	type SelfLocation = SelfLocation;
+	type WhiteListingMultiLocations = ();
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type BaseXcmWeight = BaseXcmWeight;

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -3,7 +3,7 @@ use crate as orml_xtokens;
 
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Everything, Get, Nothing},
+	traits::{Contains, Everything, Get, Nothing},
 	weights::{constants::WEIGHT_PER_SECOND, Weight},
 };
 use frame_system::EnsureRoot;
@@ -270,6 +270,48 @@ parameter_types! {
 	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::get().into())));
 	pub const BaseXcmWeight: Weight = 100_000_000;
 	pub const MaxAssetsForTransfer: usize = 2;
+	pub SupportedMultiLocations: Vec<MultiLocation> = vec![
+		MultiLocation::new(
+			1,
+			X2(
+				Parachain(1),
+				GeneralKey("A".into())
+			)
+		),
+		MultiLocation::new(
+			1,
+			X2(
+				Parachain(1),
+				GeneralKey("A1".into())
+			)
+		),
+		MultiLocation::new(
+			1,
+			X2(
+				Parachain(2),
+				GeneralKey("B".into())
+			)
+		),
+		MultiLocation::new(
+			1,
+			X2(
+				Parachain(2),
+				GeneralKey("B1".into())
+			)
+		),
+		MultiLocation::new(
+			1,
+			Junctions::Here
+		)
+	];
+}
+
+pub struct WhiteListingMultiLocations;
+impl Contains<MultiLocation> for WhiteListingMultiLocations {
+	fn contains(location: &MultiLocation) -> bool {
+		dbg!(&location);
+		SupportedMultiLocations::get().contains(location)
+	}
 }
 
 impl orml_xtokens::Config for Runtime {
@@ -279,7 +321,7 @@ impl orml_xtokens::Config for Runtime {
 	type CurrencyIdConvert = CurrencyIdConvert;
 	type AccountIdToMultiLocation = AccountIdToMultiLocation;
 	type SelfLocation = SelfLocation;
-	type WhiteListingMultiLocations = ();
+	type WhiteListingMultiLocations = WhiteListingMultiLocations;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type BaseXcmWeight = BaseXcmWeight;

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -1342,6 +1342,7 @@ fn unsupported_multilocation_should_be_filtered() {
 
 	ParaB::execute_with(|| {
 		assert_ok!(ParaTokens::deposit(CurrencyId::B, &ALICE, 1_000));
+		assert_ok!(ParaTokens::deposit(CurrencyId::B1, &ALICE, 1_000));
 		assert_noop!(
 			ParaXTokens::transfer(
 				Some(ALICE).into(),
@@ -1351,6 +1352,27 @@ fn unsupported_multilocation_should_be_filtered() {
 					(
 						Parent,
 						Parachain(4), // parachain 4 is not supported list.
+						Junction::AccountId32 {
+							network: NetworkId::Any,
+							id: BOB.into(),
+						},
+					)
+						.into()
+				),
+				40,
+			),
+			Error::<para::Runtime>::NotSupportedMultiLocation
+		);
+
+		assert_noop!(
+			ParaXTokens::transfer_multicurrencies(
+				Some(ALICE).into(),
+				vec![(CurrencyId::B1, 50), (CurrencyId::B, 450)],
+				0,
+				Box::new(
+					(
+						Parent,
+						Parachain(4),
 						Junction::AccountId32 {
 							network: NetworkId::Any,
 							id: BOB.into(),

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -1335,3 +1335,32 @@ fn send_with_zero_amount() {
 
 	// TODO: should have more tests after https://github.com/paritytech/polkadot/issues/4996
 }
+
+#[test]
+fn unsupported_multilocation_should_be_filtered() {
+	TestNet::reset();
+
+	ParaB::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::B, &ALICE, 1_000));
+		assert_noop!(
+			ParaXTokens::transfer(
+				Some(ALICE).into(),
+				CurrencyId::B,
+				500,
+				Box::new(
+					(
+						Parent,
+						Parachain(4), // parachain 4 is not supported list.
+						Junction::AccountId32 {
+							network: NetworkId::Any,
+							id: BOB.into(),
+						},
+					)
+						.into()
+				),
+				40,
+			),
+			Error::<para::Runtime>::NotSupportedMultiLocation
+		);
+	});
+}


### PR DESCRIPTION
Closes #714 

Add an associated type `MultiLocationsFilter` to filter unsupported `MultiLocation`.