### PR TITLE
Fix documentation for slashing

### DIFF
--- a/traits/src/currency.rs
+++ b/traits/src/currency.rs
@@ -79,8 +79,8 @@ pub trait MultiCurrency<AccountId> {
 
 	/// Deduct the balance of `who` by up to `amount`.
 	///
-	/// As much funds up to `amount` will be deducted as possible.  If this is
-	/// less than `amount`,then a non-zero value will be returned.
+	/// As much funds up to `amount` will be deducted as possible. If this is
+	/// less than `amount`, then a non-zero excess value will be returned.
 	fn slash(currency_id: Self::CurrencyId, who: &AccountId, amount: Self::Balance) -> Self::Balance;
 }
 
@@ -153,7 +153,7 @@ pub trait MultiReservableCurrency<AccountId>: MultiCurrency<AccountId> {
 	/// cannot fail.
 	///
 	/// As much funds up to `value` will be deducted as possible. If the reserve
-	/// balance of `who` is less than `value`, then a non-zero second item will
+	/// balance of `who` is less than `value`, then a non-zero excess will
 	/// be returned.
 	fn slash_reserved(currency_id: Self::CurrencyId, who: &AccountId, value: Self::Balance) -> Self::Balance;
 
@@ -212,7 +212,7 @@ pub trait NamedMultiReservableCurrency<AccountId>: MultiReservableCurrency<Accou
 	/// cannot fail.
 	///
 	/// As much funds up to `value` will be deducted as possible. If the reserve
-	/// balance of `who` is less than `value`, then a non-zero second item will
+	/// balance of `who` is less than `value`, then a non-zero excess will
 	/// be returned.
 	fn slash_reserved_named(
 		id: &Self::ReserveIdentifier,
@@ -403,7 +403,7 @@ pub trait BasicCurrency<AccountId> {
 	/// Deduct the balance of `who` by up to `amount`.
 	///
 	/// As much funds up to `amount` will be deducted as possible. If this is
-	/// less than `amount`,then a non-zero value will be returned.
+	/// less than `amount`, then a non-zero excess value will be returned.
 	fn slash(who: &AccountId, amount: Self::Balance) -> Self::Balance;
 }
 
@@ -465,7 +465,7 @@ pub trait BasicReservableCurrency<AccountId>: BasicCurrency<AccountId> {
 	/// cannot fail.
 	///
 	/// As much funds up to `value` will be deducted as possible. If the reserve
-	/// balance of `who` is less than `value`, then a non-zero second item will
+	/// balance of `who` is less than `value`, then a non-zero excess will
 	/// be returned.
 	fn slash_reserved(who: &AccountId, value: Self::Balance) -> Self::Balance;
 


### PR DESCRIPTION
The documentation indicates, that it would have still a first `Imbalance` element, but it hasn't.