### PR TITLE
Distinguish when `MinXcmFee` is not registered and `FeeNotEnough`

### DIFF
--- a/asset-registry/src/mock/para.rs
+++ b/asset-registry/src/mock/para.rs
@@ -283,11 +283,11 @@ match_type! {
 }
 
 parameter_type_with_key! {
-	pub ParachainMinFee: |location: MultiLocation| -> u128 {
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
 		#[allow(clippy::match_ref_pats)] // false positive
 		match (location.parents, location.first_interior()) {
-			(1, Some(Parachain(2))) => 40,
-			_ => u128::MAX,
+			(1, Some(Parachain(2))) => Some(40),
+			_ => None,
 		}
 	};
 }

--- a/traits/src/get_by_key.rs
+++ b/traits/src/get_by_key.rs
@@ -1,5 +1,3 @@
-use xcm::v1::MultiLocation;
-
 /// A trait for querying a value by a key.
 pub trait GetByKey<Key, Value> {
 	/// Return the value.
@@ -56,12 +54,4 @@ mod tests {
 		assert_eq!(Test::get(&2), 2);
 		assert_eq!(Test::get(&3), 2);
 	}
-}
-
-// Default implementation for xTokens::MinXcmFee
-pub struct DisabledParachainFee;
-impl GetByKey<MultiLocation, Option<u128>> for DisabledParachainFee {
-    fn get(_key: &MultiLocation) -> Option<u128> {
-        None
-    }
 }

--- a/traits/src/get_by_key.rs
+++ b/traits/src/get_by_key.rs
@@ -1,3 +1,5 @@
+use xcm::v1::MultiLocation;
+
 /// A trait for querying a value by a key.
 pub trait GetByKey<Key, Value> {
 	/// Return the value.
@@ -54,4 +56,12 @@ mod tests {
 		assert_eq!(Test::get(&2), 2);
 		assert_eq!(Test::get(&3), 2);
 	}
+}
+
+// Default implementation for xTokens::MinXcmFee
+pub struct DisabledParachainFee;
+impl GetByKey<MultiLocation, Option<u128>> for DisabledParachainFee {
+    fn get(_key: &MultiLocation) -> Option<u128> {
+        None
+    }
 }

--- a/xcm-support/src/lib.rs
+++ b/xcm-support/src/lib.rs
@@ -16,7 +16,7 @@ use sp_std::{marker::PhantomData, prelude::*};
 use xcm::latest::prelude::*;
 use xcm_executor::traits::{FilterAssetLocation, MatchesFungible};
 
-use orml_traits::location::Reserve;
+use orml_traits::{location::Reserve, GetByKey};
 
 pub use currency_adapter::{DepositToAlternative, MultiCurrencyAdapter, OnDepositFail};
 
@@ -76,5 +76,13 @@ impl UnknownAsset for () {
 	}
 	fn withdraw(_asset: &MultiAsset, _from: &MultiLocation) -> DispatchResult {
 		Err(DispatchError::Other(NO_UNKNOWN_ASSET_IMPL))
+	}
+}
+
+// Default implementation for xTokens::MinXcmFee
+pub struct DisabledParachainFee;
+impl GetByKey<MultiLocation, Option<u128>> for DisabledParachainFee {
+	fn get(_key: &MultiLocation) -> Option<u128> {
+		None
 	}
 }

--- a/xtokens/README.md
+++ b/xtokens/README.md
@@ -51,22 +51,22 @@ Parachains should implements config `MinXcmFee` in `xtokens` module config:
 
 ```rust
 parameter_type_with_key! {
-	pub ParachainMinFee: |location: MultiLocation| -> u128 {
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
 		#[allow(clippy::match_ref_pats)] // false positive
 		match (location.parents, location.first_interior()) {
-			(1, Some(Parachain(parachains::statemine::ID))) => 4_000_000_000,
-			_ => u128::MAX,
+			(1, Some(Parachain(parachains::statemine::ID))) => Some(4_000_000_000),
+			_ => None,
 		}
 	};
 }
 ```
 
-If Parachain don't want have this case, can simply return Max value:
+If Parachain don't want have this case, can simply return None:
 
 ```rust
 parameter_type_with_key! {
-	pub ParachainMinFee: |_location: MultiLocation| -> u128 {
-		u128::MAX
+	pub ParachainMinFee: |_location: MultiLocation| -> Option<u128> {
+		None
 	};
 }
 ```

--- a/xtokens/README.md
+++ b/xtokens/README.md
@@ -61,7 +61,7 @@ parameter_type_with_key! {
 }
 ```
 
-If Parachain don't want have this case, can simply return None:
+If Parachain don't want have this case, can simply return None. A default implementation is provided by `DisabledParachainFee` in `xcm-support`.
 
 ```rust
 parameter_type_with_key! {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -174,7 +174,7 @@ pub mod module {
 		/// Not supported MultiLocation
 		NotSupportedMultiLocation,
 		/// MinXcmFee not registered for certain reserve location
-		MinXcmFeeNotRegistered,
+		MinXcmFeeNotDefined,
 	}
 
 	#[pallet::hooks]
@@ -540,7 +540,7 @@ pub mod module {
 				ensure!(non_fee_reserve == dest.chain_part(), Error::<T>::InvalidAsset);
 
 				let reserve_location = non_fee_reserve.clone().ok_or(Error::<T>::AssetHasNoReserve)?;
-				let min_xcm_fee = T::MinXcmFee::get(&reserve_location).ok_or(Error::<T>::MinXcmFeeNotRegistered)?;
+				let min_xcm_fee = T::MinXcmFee::get(&reserve_location).ok_or(Error::<T>::MinXcmFeeNotDefined)?;
 
 				// min xcm fee should less than user fee
 				let fee_to_dest: MultiAsset = (fee.id.clone(), min_xcm_fee).into();

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -89,7 +89,7 @@ pub mod module {
 		type SelfLocation: Get<MultiLocation>;
 
 		/// Minimum xcm execution fee paid on destination chain.
-		type MinXcmFee: GetByKey<MultiLocation, u128>;
+		type MinXcmFee: GetByKey<MultiLocation, Option<u128>>;
 
 		/// XCM executor.
 		type XcmExecutor: ExecuteXcm<Self::Call>;
@@ -173,6 +173,8 @@ pub mod module {
 		FeeNotEnough,
 		/// Not supported MultiLocation
 		NotSupportedMultiLocation,
+		/// MinXcmFee not registered for certain reserve location
+		MinXcmFeeNotRegistered,
 	}
 
 	#[pallet::hooks]
@@ -538,7 +540,7 @@ pub mod module {
 				ensure!(non_fee_reserve == dest.chain_part(), Error::<T>::InvalidAsset);
 
 				let reserve_location = non_fee_reserve.clone().ok_or(Error::<T>::AssetHasNoReserve)?;
-				let min_xcm_fee = T::MinXcmFee::get(&reserve_location);
+				let min_xcm_fee = T::MinXcmFee::get(&reserve_location).ok_or(Error::<T>::MinXcmFeeNotRegistered)?;
 
 				// min xcm fee should less than user fee
 				let fee_to_dest: MultiAsset = (fee.id.clone(), min_xcm_fee).into();

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -272,11 +272,11 @@ match_types! {
 }
 
 parameter_type_with_key! {
-	pub ParachainMinFee: |location: MultiLocation| -> u128 {
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
 		#[allow(clippy::match_ref_pats)] // false positive
 		match (location.parents, location.first_interior()) {
-			(1, Some(Parachain(2))) => 40,
-			_ => u128::MAX,
+			(1, Some(Parachain(2))) => Some(40),
+			_ => None,
 		}
 	};
 }

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -339,11 +339,11 @@ match_types! {
 }
 
 parameter_type_with_key! {
-	pub ParachainMinFee: |location: MultiLocation| -> u128 {
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
 		#[allow(clippy::match_ref_pats)] // false positive
 		match (location.parents, location.first_interior()) {
-			(1, Some(Parachain(2))) => 40,
-			_ => u128::MAX,
+			(1, Some(Parachain(2))) => Some(40),
+			_ => None,
 		}
 	};
 }

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -873,7 +873,7 @@ fn transfer_asset_with_relay_fee_failed() {
 				),
 				40,
 			),
-			Error::<para::Runtime>::FeeNotEnough
+			Error::<para::Runtime>::MinXcmFeeNotDefined
 		);
 	});
 }


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

A few small changes to improve debugging and readability:
* Added a specific error to specify `MinXcmFee` is not registered, to distinguish between this case and `FeeNotEnough`
* Refactored `MinXcmFee`  return an Option, so implementers don't have to use u128::Max for unregistered locations. 
* Adjusted existing test cases