### PR TITLE
enable runtime-benchmarks on asset-registry xcm dependencies

### DIFF
--- a/asset-registry/Cargo.toml
+++ b/asset-registry/Cargo.toml
@@ -64,5 +64,8 @@ std = [
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+
+	"xcm-builder/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>