### PR TITLE
asset-registry: And and Implement `Inspect` + `Mutate` traits

### DIFF
--- a/asset-registry/src/impls.rs
+++ b/asset-registry/src/impls.rs
@@ -1,7 +1,9 @@
-use crate::{module::*, AssetMetadata};
+use crate::module::*;
 use frame_support::{log, pallet_prelude::*, weights::constants::WEIGHT_PER_SECOND};
 use orml_traits::{
-	asset_registry::{AssetProcessor, FixedConversionRateProvider, WeightToFeeConverter},
+	asset_registry::{
+		AssetMetadata, AssetProcessor, FixedConversionRateProvider, Inspect, Mutate, WeightToFeeConverter,
+	},
 	GetByKey,
 };
 use sp_runtime::FixedPointNumber;
@@ -167,5 +169,56 @@ impl<T: Config> GetByKey<T::AssetId, T::Balance> for ExistentialDeposits<T> {
 			// Asset does not exist - not supported
 			T::Balance::max_value()
 		}
+	}
+}
+
+impl<T: Config> Inspect for Pallet<T> {
+	type AssetId = T::AssetId;
+	type Balance = T::Balance;
+	type CustomMetadata = T::CustomMetadata;
+
+	fn asset_id(location: &MultiLocation) -> Option<Self::AssetId> {
+		Pallet::<T>::location_to_asset_id(location)
+	}
+
+	fn metadata(id: &Self::AssetId) -> Option<AssetMetadata<Self::Balance, Self::CustomMetadata>> {
+		Pallet::<T>::metadata(id)
+	}
+
+	fn metadata_by_location(location: &MultiLocation) -> Option<AssetMetadata<Self::Balance, Self::CustomMetadata>> {
+		Pallet::<T>::fetch_metadata_by_location(location)
+	}
+
+	fn location(asset_id: &Self::AssetId) -> Result<Option<MultiLocation>, DispatchError> {
+		Pallet::<T>::multilocation(asset_id)
+	}
+}
+
+impl<T: Config> Mutate for Pallet<T> {
+	fn register_asset(
+		asset_id: Option<Self::AssetId>,
+		metadata: AssetMetadata<Self::Balance, Self::CustomMetadata>,
+	) -> DispatchResult {
+		Pallet::<T>::do_register_asset(metadata, asset_id)
+	}
+
+	fn update_asset(
+		asset_id: Self::AssetId,
+		decimals: Option<u32>,
+		name: Option<Vec<u8>>,
+		symbol: Option<Vec<u8>>,
+		existential_deposit: Option<Self::Balance>,
+		location: Option<Option<xcm::VersionedMultiLocation>>,
+		additional: Option<Self::CustomMetadata>,
+	) -> DispatchResult {
+		Pallet::<T>::do_update_asset(
+			asset_id,
+			decimals,
+			name,
+			symbol,
+			existential_deposit,
+			location,
+			additional,
+		)
 	}
 }

--- a/asset-registry/src/impls.rs
+++ b/asset-registry/src/impls.rs
@@ -12,7 +12,8 @@ use sp_runtime::{
 	ArithmeticError, FixedU128,
 };
 use sp_std::prelude::*;
-use xcm::v2::prelude::*;
+use xcm::latest::prelude::*;
+use xcm::VersionedMultiLocation;
 use xcm_builder::TakeRevenue;
 use xcm_executor::{traits::WeightTrader, Assets};
 
@@ -208,7 +209,7 @@ impl<T: Config> Mutate for Pallet<T> {
 		name: Option<Vec<u8>>,
 		symbol: Option<Vec<u8>>,
 		existential_deposit: Option<Self::Balance>,
-		location: Option<Option<xcm::VersionedMultiLocation>>,
+		location: Option<Option<VersionedMultiLocation>>,
 		additional: Option<Self::CustomMetadata>,
 	) -> DispatchResult {
 		Pallet::<T>::do_update_asset(

--- a/asset-registry/src/lib.rs
+++ b/asset-registry/src/lib.rs
@@ -4,7 +4,8 @@
 #![allow(clippy::large_enum_variant)]
 use frame_support::{pallet_prelude::*, traits::EnsureOriginWithArg, transactional};
 use frame_system::pallet_prelude::*;
-use orml_traits::asset_registry::{AssetMetadata, AssetProcessor};
+pub use orml_traits::asset_registry::AssetMetadata;
+use orml_traits::asset_registry::AssetProcessor;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Member},

--- a/asset-registry/src/lib.rs
+++ b/asset-registry/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::large_enum_variant)]
 use frame_support::{pallet_prelude::*, traits::EnsureOriginWithArg, transactional};
 use frame_system::pallet_prelude::*;
-use orml_traits::asset_registry::AssetProcessor;
+use orml_traits::asset_registry::{AssetMetadata, AssetProcessor};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Member},
@@ -24,17 +24,6 @@ mod weights;
 mod mock;
 #[cfg(test)]
 mod tests;
-
-/// Data describing the asset properties.
-#[derive(scale_info::TypeInfo, Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
-pub struct AssetMetadata<Balance, CustomMetadata: Parameter + Member + TypeInfo> {
-	pub decimals: u32,
-	pub name: Vec<u8>,
-	pub symbol: Vec<u8>,
-	pub existential_deposit: Balance,
-	pub location: Option<VersionedMultiLocation>,
-	pub additional: CustomMetadata,
-}
 
 #[frame_support::pallet]
 pub mod module {

--- a/traits/src/asset_registry.rs
+++ b/traits/src/asset_registry.rs
@@ -1,5 +1,6 @@
 use frame_support::pallet_prelude::*;
 use sp_runtime::DispatchResult;
+use sp_std::vec::Vec;
 use xcm::latest::prelude::*;
 use xcm::VersionedMultiLocation;
 

--- a/traits/src/asset_registry.rs
+++ b/traits/src/asset_registry.rs
@@ -1,5 +1,7 @@
 use frame_support::pallet_prelude::*;
+use sp_runtime::DispatchResult;
 use xcm::latest::prelude::*;
+use xcm::VersionedMultiLocation;
 
 pub trait WeightToFeeConverter {
 	fn convert_weight_to_fee(location: &MultiLocation, weight: Weight) -> Option<u128>;
@@ -14,4 +16,46 @@ pub trait AssetProcessor<AssetId, Metadata> {
 	fn post_register(_id: AssetId, _asset_metadata: Metadata) -> Result<(), DispatchError> {
 		Ok(())
 	}
+}
+
+/// Data describing the asset properties.
+#[derive(scale_info::TypeInfo, Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
+pub struct AssetMetadata<Balance, CustomMetadata: Parameter + Member + TypeInfo> {
+	pub decimals: u32,
+	pub name: Vec<u8>,
+	pub symbol: Vec<u8>,
+	pub existential_deposit: Balance,
+	pub location: Option<VersionedMultiLocation>,
+	pub additional: CustomMetadata,
+}
+
+pub trait Inspect {
+	/// AssetId type
+	type AssetId;
+	/// Balance type
+	type Balance;
+	/// Custom metadata type
+	type CustomMetadata: Parameter + Member + TypeInfo;
+
+	fn asset_id(location: &MultiLocation) -> Option<Self::AssetId>;
+	fn metadata(asset_id: &Self::AssetId) -> Option<AssetMetadata<Self::Balance, Self::CustomMetadata>>;
+	fn metadata_by_location(location: &MultiLocation) -> Option<AssetMetadata<Self::Balance, Self::CustomMetadata>>;
+	fn location(asset_id: &Self::AssetId) -> Result<Option<MultiLocation>, DispatchError>;
+}
+
+pub trait Mutate: Inspect {
+	fn register_asset(
+		asset_id: Option<Self::AssetId>,
+		metadata: AssetMetadata<Self::Balance, Self::CustomMetadata>,
+	) -> DispatchResult;
+
+	fn update_asset(
+		asset_id: Self::AssetId,
+		decimals: Option<u32>,
+		name: Option<Vec<u8>>,
+		symbol: Option<Vec<u8>>,
+		existential_deposit: Option<Self::Balance>,
+		location: Option<Option<VersionedMultiLocation>>,
+		additional: Option<Self::CustomMetadata>,
+	) -> DispatchResult;
 }


### PR DESCRIPTION
This allows for loosely coupling of the `orml_asset_registry` pallet instead of forcing other pallets into a tight dependency.

This is particularly helpful for us at Centrifuge where we need to pass the asset-registry to a few pallets to query asset metadata and register tranche tokens.