### PR TITLE
Reanchor recipient in `to-non-reserve transfer`

### DIFF
--- a/xtokens/README.md
+++ b/xtokens/README.md
@@ -71,6 +71,6 @@ parameter_type_with_key! {
 }
 ```
 
-Notice the implementation for now also rely on `SelfLocation` which already in `xtokens` config. The `SelfLocation` current is `(1, Parachain(id))` refer to sender parachain. If parachain set `SelfLocation` to (0, Here), it'll be error in this case.
+Notice the implementation for now also relies on `SelfLocation` which is already in `xtokens` config. The `SelfLocation` is currently set to absolute view `(1, Parachain(id))` and refers to the sender parachain. However `SelfLocation` set to relative view `(0, Here)` will also work.
 
 We use `SelfLocation` to fund fee to sender's parachain sovereign account on destination parachain, which asset is originated from sender account on sender parachain. This means if user setup too much fee, the fee will not returned to user, instead deposit to sibling parachain sovereign account on destination parachain.

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -706,6 +706,12 @@ pub mod module {
 				}
 			}
 
+			let mut reanchored_recipient = recipient.clone();
+			if recipient == MultiLocation::here() {
+				let ancestry = T::LocationInverter::ancestry();
+				reanchored_recipient.reanchor(&dest, &ancestry);
+			}
+
 			if !use_teleport {
 				Ok(Xcm(vec![
 					WithdrawAsset(assets.clone()),
@@ -720,7 +726,7 @@ pub mod module {
 								dest: reanchored_dest,
 								xcm: Xcm(vec![
 									Self::buy_execution(half(&fee), &dest, dest_weight)?,
-									Self::deposit_asset(recipient, assets.len() as u32),
+									Self::deposit_asset(reanchored_recipient, assets.len() as u32),
 								]),
 							},
 						]),
@@ -739,7 +745,7 @@ pub mod module {
 								dest: reanchored_dest,
 								xcm: Xcm(vec![
 									Self::buy_execution(half(&fee), &dest, dest_weight)?,
-									Self::deposit_asset(recipient, assets.len() as u32),
+									Self::deposit_asset(reanchored_recipient, assets.len() as u32),
 								]),
 							},
 						]),

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -707,6 +707,7 @@ pub mod module {
 			}
 
 			let mut reanchored_recipient = recipient.clone();
+			println!("\n {:?} \n", recipient);
 			if recipient == MultiLocation::here() {
 				let ancestry = T::LocationInverter::ancestry();
 				let _ = reanchored_recipient

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -709,7 +709,7 @@ pub mod module {
 			let mut reanchored_recipient = recipient.clone();
 			if recipient == MultiLocation::here() {
 				let ancestry = T::LocationInverter::ancestry();
-				reanchored_recipient
+				let _ = reanchored_recipient
 					.reanchor(&dest, &ancestry)
 					.map_err(|_| DispatchError::Other("Cannot reanchor recipient"));
 			}

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -707,7 +707,6 @@ pub mod module {
 			}
 
 			let mut reanchored_recipient = recipient.clone();
-			println!("\n {:?} \n", recipient);
 			if recipient == MultiLocation::here() {
 				let ancestry = T::LocationInverter::ancestry();
 				let _ = reanchored_recipient

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -709,7 +709,9 @@ pub mod module {
 			let mut reanchored_recipient = recipient.clone();
 			if recipient == MultiLocation::here() {
 				let ancestry = T::LocationInverter::ancestry();
-				reanchored_recipient.reanchor(&dest, &ancestry);
+				reanchored_recipient
+					.reanchor(&dest, &ancestry)
+					.map_err(|_| DispatchError::Other("Cannot reanchor recipient"));
 			}
 
 			if !use_teleport {

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -307,6 +307,7 @@ parameter_type_with_key! {
 		#[allow(clippy::match_ref_pats)] // false positive
 		match (location.parents, location.first_interior()) {
 			(1, Some(Parachain(2))) => Some(40),
+			(1, Some(Parachain(3))) => Some(40),
 			_ => None,
 		}
 	};

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -726,7 +726,7 @@ fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_works_with_relative_s
 	let dest_weight: u128 = 40;
 
 	ParaD::execute_with(|| {
-		assert_ok!(ParaXTokens::transfer_multicurrencies(
+		assert_ok!(ParaRelativeXTokens::transfer_multicurrencies(
 			Some(ALICE).into(),
 			vec![(CurrencyId::C, 450), (CurrencyId::R, fee_amount)],
 			1,
@@ -743,8 +743,11 @@ fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_works_with_relative_s
 			),
 			weight as u64,
 		));
-		assert_eq!(550, ParaTokens::free_balance(CurrencyId::C, &ALICE));
-		assert_eq!(1000 - fee_amount, ParaTokens::free_balance(CurrencyId::R, &ALICE));
+		assert_eq!(550, ParaRelativeTokens::free_balance(CurrencyId::C, &ALICE));
+		assert_eq!(
+			1000 - fee_amount,
+			ParaRelativeTokens::free_balance(CurrencyId::R, &ALICE)
+		);
 	});
 
 	Relay::execute_with(|| {

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -706,6 +706,66 @@ fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_works() {
 }
 
 #[test]
+fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_works_with_relative_self_location() {
+	TestNet::reset();
+
+	ParaD::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::C, &ALICE, 1_000));
+	});
+
+	ParaC::execute_with(|| {
+		assert_ok!(ParaTeleportTokens::deposit(CurrencyId::C, &sibling_d_account(), 1_000));
+	});
+
+	Relay::execute_with(|| {
+		let _ = RelayBalances::deposit_creating(&para_d_account(), 1_000);
+	});
+
+	let fee_amount: u128 = 200;
+	let weight: u128 = 50;
+	let dest_weight: u128 = 40;
+
+	ParaD::execute_with(|| {
+		assert_ok!(ParaXTokens::transfer_multicurrencies(
+			Some(ALICE).into(),
+			vec![(CurrencyId::C, 450), (CurrencyId::R, fee_amount)],
+			1,
+			Box::new(
+				(
+					Parent,
+					Parachain(3),
+					Junction::AccountId32 {
+						network: NetworkId::Any,
+						id: BOB.into(),
+					},
+				)
+					.into()
+			),
+			weight as u64,
+		));
+		assert_eq!(550, ParaTokens::free_balance(CurrencyId::C, &ALICE));
+		assert_eq!(1000 - fee_amount, ParaTokens::free_balance(CurrencyId::R, &ALICE));
+	});
+
+	Relay::execute_with(|| {
+		assert_eq!(
+			1000 - (fee_amount - dest_weight),
+			RelayBalances::free_balance(&para_d_account())
+		);
+	});
+
+	ParaC::execute_with(|| {
+		assert_eq!(
+			fee_amount - dest_weight * 4,
+			ParaTeleportTokens::free_balance(CurrencyId::R, &sibling_d_account())
+		);
+
+		assert_eq!(450, ParaTeleportTokens::free_balance(CurrencyId::C, &BOB));
+		assert_eq!(0, ParaTeleportTokens::free_balance(CurrencyId::R, &BOB));
+	});
+}
+
+#[test]
 fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_not_enough() {
 	TestNet::reset();
 


### PR DESCRIPTION
* In the case of sending back assets to statemine the recipient is overriden with `SelfLocation` and when this self location is in relative view, it will not be interpreted correctly on the receiver chain.
* So to support relative views in this case, we can simply reanchor the recipient from the point of view of the destination chain. However only in the case of the recipient being (0, Here)
* Added a test case for this - `sending_sibling_asset_to_reserve_sibling_with_relay_fee_works_with_relative_self_location`

Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>