### PR TITLE
bump jsonrpsee to 0.15.1

### DIFF
--- a/oracle/rpc/Cargo.toml
+++ b/oracle/rpc/Cargo.toml
@@ -8,7 +8,7 @@ description = "RPC module for orml-oracle."
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.14.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 tracing = { version = "0.1.29" }
 tracing-core = { version = "0.1.28" }
 

--- a/tokens/rpc/Cargo.toml
+++ b/tokens/rpc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.14.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 tracing = { version = "0.1.29" }
 tracing-core = { version = "0.1.28" }
 


### PR DESCRIPTION
Hi, there is en error when bump to polkadot-0.9.28
Refer: https://github.com/paritytech/substrate/pull/11939
![image](https://user-images.githubusercontent.com/26266313/188834743-3f7a5912-0a0d-4244-99a8-8c7398602258.png)


