### PR TITLE
fix small issue with weighting transfer_multiasset

### DIFF
--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -824,7 +824,7 @@ pub mod module {
 				{
 					let mut msg = match transfer_kind {
 						SelfReserveAsset => Xcm(vec![TransferReserveAsset {
-							assets: vec![].into(),
+							assets: vec![asset].into(),
 							dest,
 							xcm: Xcm(vec![]),
 						}]),


### PR DESCRIPTION
Fixes small issue when calculating weight in `transfer_multiasset`. If using constant weight per instruction should not affect