### PR TITLE
feat(tokens): OnDeposit, OnTransfer, OnSlash hooks

### DIFF
--- a/asset-registry/src/mock/para.rs
+++ b/asset-registry/src/mock/para.rs
@@ -93,6 +93,9 @@ impl orml_tokens::Config for Runtime {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type ReserveIdentifier = [u8; 8];
 	type MaxReserves = ();
 	type MaxLocks = ConstU32<50>;

--- a/currencies/src/mock.rs
+++ b/currencies/src/mock.rs
@@ -81,6 +81,9 @@ impl orml_tokens::Config for Runtime {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = orml_tokens::TransferDust<Runtime, DustAccount>;
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type MaxLocks = ConstU32<100_000>;
 	type MaxReserves = ConstU32<100_000>;
 	type ReserveIdentifier = ReserveIdentifier;

--- a/payments/src/mock.rs
+++ b/payments/src/mock.rs
@@ -99,6 +99,9 @@ impl orml_tokens::Config for Test {
 	type Event = Event;
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type WeightInfo = ();
 	type MaxLocks = MaxLocks;
 	type DustRemovalWhitelist = MockDustRemovalWhitelist;

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -901,11 +901,11 @@ impl<T: Config> Pallet<T> {
 		amount: T::Balance,
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
-		T::OnTransfer::on_transfer(currency_id, from, to, amount)?;
 		if amount.is_zero() || from == to {
 			return Ok(());
 		}
 
+		T::OnTransfer::on_transfer(currency_id, from, to, amount)?;
 		Self::try_mutate_account(to, currency_id, |to_account, _existed| -> DispatchResult {
 			Self::try_mutate_account(from, currency_id, |from_account, _existed| -> DispatchResult {
 				from_account.free = from_account
@@ -1027,11 +1027,11 @@ impl<T: Config> Pallet<T> {
 		require_existed: bool,
 		change_total_issuance: bool,
 	) -> DispatchResult {
-		T::OnDeposit::on_deposit(currency_id, who, amount)?;
 		if amount.is_zero() {
 			return Ok(());
 		}
 
+		T::OnDeposit::on_deposit(currency_id, who, amount)?;
 		Self::try_mutate_account(who, currency_id, |account, existed| -> DispatchResult {
 			if require_existed {
 				ensure!(existed, Error::<T>::DeadAccount);
@@ -1123,11 +1123,11 @@ impl<T: Config> MultiCurrency<T::AccountId> for Pallet<T> {
 	/// reserved funds, however we err on the side of punishment if things
 	/// are inconsistent or `can_slash` wasn't used appropriately.
 	fn slash(currency_id: Self::CurrencyId, who: &T::AccountId, amount: Self::Balance) -> Self::Balance {
-		T::OnSlash::on_slash(currency_id, who, amount);
 		if amount.is_zero() {
 			return amount;
 		}
 
+		T::OnSlash::on_slash(currency_id, who, amount);
 		let account = Self::accounts(who, currency_id);
 		let free_slashed_amount = account.free.min(amount);
 		// Cannot underflow because free_slashed_amount can never be greater than amount
@@ -1290,11 +1290,11 @@ impl<T: Config> MultiReservableCurrency<T::AccountId> for Pallet<T> {
 	///
 	/// Is a no-op if the value to be slashed is zero.
 	fn slash_reserved(currency_id: Self::CurrencyId, who: &T::AccountId, value: Self::Balance) -> Self::Balance {
-		T::OnSlash::on_slash(currency_id, who, value);
 		if value.is_zero() {
 			return value;
 		}
 
+		T::OnSlash::on_slash(currency_id, who, value);
 		let reserved_balance = Self::reserved_balance(currency_id, who);
 		let actual = reserved_balance.min(value);
 		Self::mutate_account(who, currency_id, |account, _| {

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -280,6 +280,9 @@ impl Config for Runtime {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = TransferDust<Runtime, DustReceiver>;
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = TrackCreatedAccounts;
 	type OnKilledTokenAccount = TrackKilledAccounts;
 	type MaxLocks = ConstU32<2>;

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -268,6 +268,55 @@ impl Happened<(AccountId, CurrencyId)> for TrackKilledAccounts {
 	}
 }
 
+thread_local! {
+	pub static ON_SLASH_CALLS: RefCell<u32> = RefCell::new(0);
+	pub static ON_DEPOSIT_CALLS: RefCell<u32> = RefCell::new(0);
+	pub static ON_TRANSFER_CALLS: RefCell<u32> = RefCell::new(0);
+}
+
+pub struct OnSlashHook<T>(marker::PhantomData<T>);
+impl<T: Config> OnSlash<T::AccountId, CurrencyId, Balance> for OnSlashHook<T> {
+	fn on_slash(_currency_id: CurrencyId, _account_id: &T::AccountId, _amount: Balance) {
+		ON_SLASH_CALLS.with(|cell| *cell.borrow_mut() += 1);
+	}
+}
+impl<T: Config> OnSlashHook<T> {
+	pub fn calls() -> u32 {
+		ON_SLASH_CALLS.with(|accounts| accounts.borrow().clone())
+	}
+}
+
+pub struct OnDepositHook<T>(marker::PhantomData<T>);
+impl<T: Config> OnDeposit<T::AccountId, CurrencyId, Balance> for OnDepositHook<T> {
+	fn on_deposit(_currency_id: CurrencyId, _account_id: &T::AccountId, _amount: Balance) -> DispatchResult {
+		ON_DEPOSIT_CALLS.with(|cell| *cell.borrow_mut() += 1);
+		Ok(())
+	}
+}
+impl<T: Config> OnDepositHook<T> {
+	pub fn calls() -> u32 {
+		ON_DEPOSIT_CALLS.with(|accounts| accounts.borrow().clone())
+	}
+}
+
+pub struct OnTransferHook<T>(marker::PhantomData<T>);
+impl<T: Config> OnTransfer<T::AccountId, CurrencyId, Balance> for OnTransferHook<T> {
+	fn on_transfer(
+		_currency_id: CurrencyId,
+		_from: &T::AccountId,
+		_to: &T::AccountId,
+		_amount: Balance,
+	) -> DispatchResult {
+		ON_TRANSFER_CALLS.with(|cell| *cell.borrow_mut() += 1);
+		Ok(())
+	}
+}
+impl<T: Config> OnTransferHook<T> {
+	pub fn calls() -> u32 {
+		ON_TRANSFER_CALLS.with(|accounts| accounts.borrow().clone())
+	}
+}
+
 parameter_types! {
 	pub DustReceiver: AccountId = PalletId(*b"orml/dst").into_account_truncating();
 }
@@ -280,9 +329,9 @@ impl Config for Runtime {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = TransferDust<Runtime, DustReceiver>;
-	type OnSlash = ();
-	type OnDeposit = ();
-	type OnTransfer = ();
+	type OnSlash = OnSlashHook<Runtime>;
+	type OnDeposit = OnDepositHook<Runtime>;
+	type OnTransfer = OnTransferHook<Runtime>;
 	type OnNewTokenAccount = TrackCreatedAccounts;
 	type OnKilledTokenAccount = TrackKilledAccounts;
 	type MaxLocks = ConstU32<2>;

--- a/traits/src/currency.rs
+++ b/traits/src/currency.rs
@@ -657,3 +657,34 @@ impl<AccountId> TransferAll<AccountId> for Tuple {
 		Ok(())
 	}
 }
+
+/// Hook to run before slashing an account.
+pub trait OnSlash<AccountId, CurrencyId, Balance> {
+	fn on_slash(currency_id: CurrencyId, who: &AccountId, amount: Balance);
+}
+
+impl<AccountId, CurrencyId, Balance> OnSlash<AccountId, CurrencyId, Balance> for () {
+	fn on_slash(_: CurrencyId, _: &AccountId, _: Balance) {}
+}
+
+/// Hook to run before depositing into an account.
+pub trait OnDeposit<AccountId, CurrencyId, Balance> {
+	fn on_deposit(currency_id: CurrencyId, who: &AccountId, amount: Balance) -> DispatchResult;
+}
+
+impl<AccountId, CurrencyId, Balance> OnDeposit<AccountId, CurrencyId, Balance> for () {
+	fn on_deposit(_: CurrencyId, _: &AccountId, _: Balance) -> DispatchResult {
+		Ok(())
+	}
+}
+
+/// Hook to run before transferring from an account to another.
+pub trait OnTransfer<AccountId, CurrencyId, Balance> {
+	fn on_transfer(currency_id: CurrencyId, from: &AccountId, to: &AccountId, amount: Balance) -> DispatchResult;
+}
+
+impl<AccountId, CurrencyId, Balance> OnTransfer<AccountId, CurrencyId, Balance> for () {
+	fn on_transfer(_: CurrencyId, _: &AccountId, _: &AccountId, _: Balance) -> DispatchResult {
+		Ok(())
+	}
+}

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -84,6 +84,9 @@ impl orml_tokens::Config for Runtime {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type MaxLocks = ConstU32<50>;
 	type MaxReserves = ConstU32<50>;
 	type ReserveIdentifier = [u8; 8];

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -87,6 +87,9 @@ impl orml_tokens::Config for Runtime {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type MaxLocks = ConstU32<50>;
 	type MaxReserves = ConstU32<50>;
 	type ReserveIdentifier = [u8; 8];

--- a/xtokens/src/mock/para_teleport.rs
+++ b/xtokens/src/mock/para_teleport.rs
@@ -85,6 +85,9 @@ impl orml_tokens::Config for Runtime {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type MaxLocks = ConstU32<50>;
 	type MaxReserves = ConstU32<50>;
 	type ReserveIdentifier = [u8; 8];


### PR DESCRIPTION
Adds configurable hooks to the Tokens pallet, for functions which emit `Event::Deposited`, `Event::Transfer`, `Event::Slashed`. A hook call is not added to `slash_reserved_named(...)`, because that function calls `slash_reserved(...)` so the hook is run there.

These hooks enable tokenizing "positions" which require lazy operations to be executed each time they are modified. An example would be tokenizing one's nomination / stake. For Alice to send her nominated position (the right to claim the nominated tokens) to Bob, her nomination rewards have to first be collected. In this example, the transfer hook would collect the sender's rewards before the actual transfer occurs.