### PR TITLE
#xcm if assets is of lower decimal then we want then pow it local

### DIFF
--- a/asset-registry/src/mock/para.rs
+++ b/asset-registry/src/mock/para.rs
@@ -17,7 +17,7 @@ use orml_traits::{
 	location::{AbsoluteReserveProvider, RelativeReserveProvider},
 	parameter_type_with_key, FixedConversionRateProvider, MultiCurrency,
 };
-use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
+use orml_xcm_support::{EqualDecimalsNormalizer, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use sp_core::H256;
@@ -184,6 +184,7 @@ pub type LocalAssetTransactor = MultiCurrencyAdapter<
 	CurrencyId,
 	CurrencyIdConvert,
 	(),
+	EqualDecimalsNormalizer,
 >;
 
 pub type XcmRouter = ParachainXcmRouter<ParachainInfo>;

--- a/xcm-support/Cargo.toml
+++ b/xcm-support/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2021"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 
+num-traits = { version = "0.2.14", default-features = false }
+
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.29" }

--- a/xcm-support/src/lib.rs
+++ b/xcm-support/src/lib.rs
@@ -18,7 +18,7 @@ use xcm_executor::traits::{FilterAssetLocation, MatchesFungible};
 
 use orml_traits::{location::Reserve, GetByKey};
 
-pub use currency_adapter::{DepositToAlternative, MultiCurrencyAdapter, OnDepositFail};
+pub use currency_adapter::{DepositToAlternative, EqualDecimalsNormalizer, MultiCurrencyAdapter, OnDepositFail};
 
 mod currency_adapter;
 

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -27,7 +27,7 @@ use xcm_executor::{Config, XcmExecutor};
 
 use crate::mock::AllTokensAreCreatedEqualToWeight;
 use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
-use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
+use orml_xcm_support::{EqualDecimalsNormalizer, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 
 pub type AccountId = AccountId32;
 
@@ -132,6 +132,7 @@ pub type LocalAssetTransactor = MultiCurrencyAdapter<
 	CurrencyId,
 	CurrencyIdConvert,
 	(),
+	EqualDecimalsNormalizer,
 >;
 
 pub type XcmRouter = ParachainXcmRouter<ParachainInfo>;

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -30,7 +30,7 @@ use orml_traits::{
 	location::{AbsoluteReserveProvider, RelativeReserveProvider},
 	parameter_type_with_key,
 };
-use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
+use orml_xcm_support::{EqualDecimalsNormalizer, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 
 pub type AccountId = AccountId32;
 
@@ -135,6 +135,7 @@ pub type LocalAssetTransactor = MultiCurrencyAdapter<
 	CurrencyId,
 	CurrencyIdConvert,
 	(),
+	EqualDecimalsNormalizer,
 >;
 
 pub type XcmRouter = ParachainXcmRouter<ParachainInfo>;


### PR DESCRIPTION
# motivation

- we want to normalize all arriving xcm assets to specific decimals

# implementation 

- default impl is no normalization
- only safe path of rising precision is used (xcm asset use reserver precision, local use increased)
