### PR TITLE
Applied fixes for unbalanced traits

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1729,18 +1729,23 @@ impl<T: Config> fungibles::Transfer<T::AccountId> for Pallet<T> {
 
 impl<T: Config> fungibles::Unbalanced<T::AccountId> for Pallet<T> {
 	fn set_balance(asset_id: Self::AssetId, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
-		// Balance is the same type and will not overflow
-		Self::mutate_account(who, asset_id, |account, _| {
-			account.free = amount;
+		// Balance is the same type and will not overflow.
+		// Provided `fungibles::Unbalanced` functions always provide `set_balance` with `free + reserved`.
+		// free = new_balance - reserved
+		Self::mutate_account(who, asset_id, |account, _| -> DispatchResult {
+			account.free = amount
+				.checked_sub(&account.reserved)
+				.ok_or(ArithmeticError::Underflow)?;
 
 			Self::deposit_event(Event::BalanceSet {
 				currency_id: asset_id,
 				who: who.clone(),
-				free: amount,
+				free: account.free,
 				reserved: account.reserved,
 			});
-		});
-		Ok(())
+
+			Ok(())
+		})
 	}
 
 	fn set_total_issuance(asset_id: Self::AssetId, amount: Self::Balance) {

--- a/tokens/src/tests_events.rs
+++ b/tokens/src/tests_events.rs
@@ -202,7 +202,7 @@ fn pallet_fungibles_unbalanced_deposit_events() {
 			System::assert_last_event(Event::Tokens(crate::Event::BalanceSet {
 				currency_id: DOT,
 				who: ALICE,
-				free: 500,
+				free: 450,
 				reserved: 50,
 			}));
 


### PR DESCRIPTION
Applied the fixes found in #823 to branch `polkadot-v0.9.27`

Our runtime still depend on Polkadot v0.9.27. However, this fix is necessary our runtime to function as expected.