### PR TITLE
fix(tokens): PostDeposit hook

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1054,19 +1054,19 @@ impl<T: Config> Pallet<T> {
 				TotalIssuance::<T>::mutate(currency_id, |v| *v = new_total_issuance);
 			}
 			account.free = account.free.defensive_saturating_add(amount);
-
-			<T::CurrencyHooks as MutationHooks<T::AccountId, T::CurrencyId, T::Balance>>::PostDeposit::on_deposit(
-				currency_id,
-				who,
-				amount,
-			)?;
-			Self::deposit_event(Event::Deposited {
-				currency_id,
-				who: who.clone(),
-				amount,
-			});
 			Ok(())
-		})
+		})?;
+		<T::CurrencyHooks as MutationHooks<T::AccountId, T::CurrencyId, T::Balance>>::PostDeposit::on_deposit(
+			currency_id,
+			who,
+			amount,
+		)?;
+		Self::deposit_event(Event::Deposited {
+			currency_id,
+			who: who.clone(),
+			amount,
+		});
+		Ok(())
 	}
 }
 

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -331,9 +331,9 @@ impl<T: Config> OnDeposit<T::AccountId, T::CurrencyId, T::Balance> for PostDepos
 		ON_DEPOSIT_POSTHOOK_CALLS.with(|cell| *cell.borrow_mut() += 1);
 		let account_balance: AccountData<T::Balance> =
 			tokens::Pallet::<T>::accounts::<T::AccountId, T::CurrencyId>(account_id.clone(), currency_id);
-		ensure!(
+		assert!(
 			account_balance.free.ge(&amount),
-			DispatchError::Other("Posthook must run after the account balance is updated.")
+			"Posthook must run after the account balance is updated."
 		);
 		Ok(())
 	}
@@ -373,9 +373,9 @@ impl<T: Config> OnTransfer<T::AccountId, T::CurrencyId, T::Balance> for PostTran
 		ON_TRANSFER_POSTHOOK_CALLS.with(|cell| *cell.borrow_mut() += 1);
 		let account_balance: AccountData<T::Balance> =
 			tokens::Pallet::<T>::accounts::<T::AccountId, T::CurrencyId>(to.clone(), currency_id);
-		ensure!(
+		assert!(
 			account_balance.free.ge(&amount),
-			DispatchError::Other("Posthook must run after the account balance is updated.")
+			"Posthook must run after the account balance is updated."
 		);
 		Ok(())
 	}

--- a/tokens/src/mock.rs
+++ b/tokens/src/mock.rs
@@ -327,8 +327,14 @@ impl<T: Config> PreDeposit<T> {
 
 pub struct PostDeposit<T>(marker::PhantomData<T>);
 impl<T: Config> OnDeposit<T::AccountId, T::CurrencyId, T::Balance> for PostDeposit<T> {
-	fn on_deposit(_currency_id: T::CurrencyId, _account_id: &T::AccountId, _amount: T::Balance) -> DispatchResult {
+	fn on_deposit(currency_id: T::CurrencyId, account_id: &T::AccountId, amount: T::Balance) -> DispatchResult {
 		ON_DEPOSIT_POSTHOOK_CALLS.with(|cell| *cell.borrow_mut() += 1);
+		let account_balance: AccountData<T::Balance> =
+			tokens::Pallet::<T>::accounts::<T::AccountId, T::CurrencyId>(account_id.clone(), currency_id);
+		ensure!(
+			account_balance.free.ge(&amount),
+			DispatchError::Other("Posthook must run after the account balance is updated.")
+		);
 		Ok(())
 	}
 }
@@ -359,12 +365,18 @@ impl<T: Config> PreTransfer<T> {
 pub struct PostTransfer<T>(marker::PhantomData<T>);
 impl<T: Config> OnTransfer<T::AccountId, T::CurrencyId, T::Balance> for PostTransfer<T> {
 	fn on_transfer(
-		_currency_id: T::CurrencyId,
+		currency_id: T::CurrencyId,
 		_from: &T::AccountId,
-		_to: &T::AccountId,
-		_amount: T::Balance,
+		to: &T::AccountId,
+		amount: T::Balance,
 	) -> DispatchResult {
 		ON_TRANSFER_POSTHOOK_CALLS.with(|cell| *cell.borrow_mut() += 1);
+		let account_balance: AccountData<T::Balance> =
+			tokens::Pallet::<T>::accounts::<T::AccountId, T::CurrencyId>(to.clone(), currency_id);
+		ensure!(
+			account_balance.free.ge(&amount),
+			DispatchError::Other("Posthook must run after the account balance is updated.")
+		);
 		Ok(())
 	}
 }


### PR DESCRIPTION
The `PostDeposit` hook was running inside `try_mutate_account`, so the user's balance was still equal to the pre-deposit amount. This caused certain post-deposit actions to fail.

#### Reason why this was not caught in the tests
The post-hook tests just increment a variable, so there are no real side effects. I thought about adding balance-changing posthooks inside the mock runtime, but those hooks would affect the results of many other tests. I don't think there's an easy way to use multiple mock runtimes in unit tests either.