### PR TITLE
refactor: make weight argument in xtokens transfers optional

### DIFF
--- a/asset-registry/src/tests.rs
+++ b/asset-registry/src/tests.rs
@@ -118,7 +118,7 @@ fn send_self_parachain_asset_to_sibling() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited,
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::RegisteredAsset(1), &ALICE), 500);
@@ -204,7 +204,7 @@ fn send_sibling_asset_to_non_reserve_sibling() {
 				)
 				.into()
 			),
-			40
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::RegisteredAsset(1), &ALICE), 500);
 	});
@@ -302,7 +302,7 @@ fn test_fixed_rate_asset_trader() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited,
 		));
 	});
 
@@ -353,7 +353,7 @@ fn test_fixed_rate_asset_trader() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited,
 		));
 	});
 

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -9,7 +9,7 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		currency_id: CurrencyId,
 		amount: Balance,
 		dest: MultiLocation,
-		dest_weight: WeightLimit,
+		dest_weight_limit: WeightLimit,
 	) -> DispatchResult;
 
 	/// Transfer `MultiAsset`
@@ -17,6 +17,6 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		who: AccountId,
 		asset: MultiAsset,
 		dest: MultiLocation,
-		dest_weight: WeightLimit,
+		dest_weight_limit: WeightLimit,
 	) -> DispatchResult;
 }

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -1,5 +1,5 @@
 use frame_support::dispatch::DispatchResult;
-use xcm::latest::{prelude::*, Weight};
+use xcm::latest::prelude::*;
 
 /// Abstraction over cross-chain token transfers.
 pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
@@ -9,7 +9,7 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		currency_id: CurrencyId,
 		amount: Balance,
 		dest: MultiLocation,
-		dest_weight: Weight,
+		dest_weight: WeightLimit,
 	) -> DispatchResult;
 
 	/// Transfer `MultiAsset`
@@ -17,6 +17,6 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		who: AccountId,
 		asset: MultiAsset,
 		dest: MultiLocation,
-		dest_weight: Weight,
+		dest_weight: WeightLimit,
 	) -> DispatchResult;
 }

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -205,7 +205,7 @@ pub mod module {
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
@@ -229,7 +229,7 @@ pub mod module {
 			origin: OriginFor<T>,
 			asset: Box<VersionedMultiAsset>,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let asset: MultiAsset = (*asset).try_into().map_err(|()| Error::<T>::BadVersion)?;
@@ -265,7 +265,7 @@ pub mod module {
 			amount: T::Balance,
 			fee: T::Balance,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
@@ -300,7 +300,7 @@ pub mod module {
 			asset: Box<VersionedMultiAsset>,
 			fee: Box<VersionedMultiAsset>,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let asset: MultiAsset = (*asset).try_into().map_err(|()| Error::<T>::BadVersion)?;
@@ -331,7 +331,7 @@ pub mod module {
 			currencies: Vec<(T::CurrencyId, T::Balance)>,
 			fee_item: u32,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
@@ -360,7 +360,7 @@ pub mod module {
 			assets: Box<VersionedMultiAssets>,
 			fee_item: u32,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let assets: MultiAssets = (*assets).try_into().map_err(|()| Error::<T>::BadVersion)?;
@@ -379,7 +379,7 @@ pub mod module {
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
@@ -400,7 +400,7 @@ pub mod module {
 			amount: T::Balance,
 			fee: T::Balance,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
@@ -427,7 +427,7 @@ pub mod module {
 			who: T::AccountId,
 			asset: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			Self::do_transfer_multiassets(who, vec![asset.clone()].into(), asset, dest, dest_weight)
 		}
@@ -437,7 +437,7 @@ pub mod module {
 			asset: MultiAsset,
 			fee: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			// Push contains saturated addition, so we should be able to use it safely
 			let mut assets = MultiAssets::new();
@@ -454,7 +454,7 @@ pub mod module {
 			currencies: Vec<(T::CurrencyId, T::Balance)>,
 			fee_item: u32,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			ensure!(
 				currencies.len() <= T::MaxAssetsForTransfer::get(),
@@ -496,7 +496,7 @@ pub mod module {
 			assets: MultiAssets,
 			fee: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			ensure!(
 				assets.len() <= T::MaxAssetsForTransfer::get(),
@@ -576,7 +576,7 @@ pub mod module {
 					fee_reserve,
 					&dest,
 					Some(override_recipient),
-					dest_weight,
+					dest_weight.clone(),
 					true,
 				)?;
 
@@ -623,7 +623,7 @@ pub mod module {
 			reserve: Option<MultiLocation>,
 			dest: &MultiLocation,
 			maybe_recipient_override: Option<MultiLocation>,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 			use_teleport: bool,
 		) -> DispatchResult {
 			let (transfer_kind, dest, reserve, recipient) = Self::transfer_kind(reserve, dest)?;
@@ -656,7 +656,7 @@ pub mod module {
 			fee: MultiAsset,
 			dest: MultiLocation,
 			recipient: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> Result<Xcm<T::RuntimeCall>, DispatchError> {
 			Ok(Xcm(vec![TransferReserveAsset {
 				assets: assets.clone(),
@@ -673,7 +673,7 @@ pub mod module {
 			fee: MultiAsset,
 			reserve: MultiLocation,
 			recipient: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> Result<Xcm<T::RuntimeCall>, DispatchError> {
 			Ok(Xcm(vec![
 				WithdrawAsset(assets.clone()),
@@ -694,7 +694,7 @@ pub mod module {
 			reserve: MultiLocation,
 			dest: MultiLocation,
 			recipient: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 			use_teleport: bool,
 		) -> Result<Xcm<T::RuntimeCall>, DispatchError> {
 			let mut reanchored_dest = dest.clone();
@@ -717,7 +717,7 @@ pub mod module {
 						assets: All.into(),
 						reserve: reserve.clone(),
 						xcm: Xcm(vec![
-							Self::buy_execution(half(&fee), &reserve, dest_weight)?,
+							Self::buy_execution(half(&fee), &reserve, dest_weight.clone())?,
 							DepositReserveAsset {
 								assets: All.into(),
 								max_assets: assets.len() as u32,
@@ -737,7 +737,7 @@ pub mod module {
 						assets: All.into(),
 						reserve: reserve.clone(),
 						xcm: Xcm(vec![
-							Self::buy_execution(half(&fee), &reserve, dest_weight)?,
+							Self::buy_execution(half(&fee), &reserve, dest_weight.clone())?,
 							InitiateTeleport {
 								assets: All.into(),
 								dest: reanchored_dest,
@@ -763,15 +763,16 @@ pub mod module {
 		fn buy_execution(
 			asset: MultiAsset,
 			at: &MultiLocation,
-			weight: Weight,
+			weight: WeightLimit,
 		) -> Result<Instruction<()>, DispatchError> {
 			let ancestry = T::LocationInverter::ancestry();
 			let fees = asset
 				.reanchored(at, &ancestry)
 				.map_err(|_| Error::<T>::CannotReanchor)?;
+
 			Ok(BuyExecution {
 				fees,
-				weight_limit: WeightLimit::Limited(weight),
+				weight_limit: weight,
 			})
 		}
 
@@ -931,7 +932,7 @@ pub mod module {
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			Self::do_transfer(who, currency_id, amount, dest, dest_weight)
 		}
@@ -941,7 +942,7 @@ pub mod module {
 			who: T::AccountId,
 			asset: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: Weight,
+			dest_weight: WeightLimit,
 		) -> DispatchResult {
 			Self::do_transfer_multiasset(who, asset, dest, dest_weight)
 		}

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -189,9 +189,9 @@ pub mod module {
 	impl<T: Config> Pallet<T> {
 		/// Transfer native currencies.
 		///
-		/// `dest_weight` is the weight for XCM execution on the dest chain, and
-		/// it would be charged from the transferred assets. If set below
-		/// requirements, the execution may fail and assets wouldn't be
+		/// `dest_weight_limit` is the weight for XCM execution on the dest
+		/// chain, and it would be charged from the transferred assets. If set
+		/// below requirements, the execution may fail and assets wouldn't be
 		/// received.
 		///
 		/// It's a no-op if any error on local XCM execution or message sending.
@@ -205,18 +205,18 @@ pub mod module {
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
-			Self::do_transfer(who, currency_id, amount, dest, dest_weight)
+			Self::do_transfer(who, currency_id, amount, dest, dest_weight_limit)
 		}
 
 		/// Transfer `MultiAsset`.
 		///
-		/// `dest_weight` is the weight for XCM execution on the dest chain, and
-		/// it would be charged from the transferred assets. If set below
-		/// requirements, the execution may fail and assets wouldn't be
+		/// `dest_weight_limit` is the weight for XCM execution on the dest
+		/// chain, and it would be charged from the transferred assets. If set
+		/// below requirements, the execution may fail and assets wouldn't be
 		/// received.
 		///
 		/// It's a no-op if any error on local XCM execution or message sending.
@@ -229,20 +229,20 @@ pub mod module {
 			origin: OriginFor<T>,
 			asset: Box<VersionedMultiAsset>,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let asset: MultiAsset = (*asset).try_into().map_err(|()| Error::<T>::BadVersion)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
-			Self::do_transfer_multiasset(who, asset, dest, dest_weight)
+			Self::do_transfer_multiasset(who, asset, dest, dest_weight_limit)
 		}
 
 		/// Transfer native currencies specifying the fee and amount as
 		/// separate.
 		///
-		/// `dest_weight` is the weight for XCM execution on the dest chain, and
-		/// it would be charged from the transferred assets. If set below
-		/// requirements, the execution may fail and assets wouldn't be
+		/// `dest_weight_limit` is the weight for XCM execution on the dest
+		/// chain, and it would be charged from the transferred assets. If set
+		/// below requirements, the execution may fail and assets wouldn't be
 		/// received.
 		///
 		/// `fee` is the amount to be spent to pay for execution in destination
@@ -265,19 +265,19 @@ pub mod module {
 			amount: T::Balance,
 			fee: T::Balance,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
 
-			Self::do_transfer_with_fee(who, currency_id, amount, fee, dest, dest_weight)
+			Self::do_transfer_with_fee(who, currency_id, amount, fee, dest, dest_weight_limit)
 		}
 
 		/// Transfer `MultiAsset` specifying the fee and amount as separate.
 		///
-		/// `dest_weight` is the weight for XCM execution on the dest chain, and
-		/// it would be charged from the transferred assets. If set below
-		/// requirements, the execution may fail and assets wouldn't be
+		/// `dest_weight_limit` is the weight for XCM execution on the dest
+		/// chain, and it would be charged from the transferred assets. If set
+		/// below requirements, the execution may fail and assets wouldn't be
 		/// received.
 		///
 		/// `fee` is the multiasset to be spent to pay for execution in
@@ -300,21 +300,21 @@ pub mod module {
 			asset: Box<VersionedMultiAsset>,
 			fee: Box<VersionedMultiAsset>,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let asset: MultiAsset = (*asset).try_into().map_err(|()| Error::<T>::BadVersion)?;
 			let fee: MultiAsset = (*fee).try_into().map_err(|()| Error::<T>::BadVersion)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
 
-			Self::do_transfer_multiasset_with_fee(who, asset, fee, dest, dest_weight)
+			Self::do_transfer_multiasset_with_fee(who, asset, fee, dest, dest_weight_limit)
 		}
 
 		/// Transfer several currencies specifying the item to be used as fee
 		///
-		/// `dest_weight` is the weight for XCM execution on the dest chain, and
-		/// it would be charged from the transferred assets. If set below
-		/// requirements, the execution may fail and assets wouldn't be
+		/// `dest_weight_limit` is the weight for XCM execution on the dest
+		/// chain, and it would be charged from the transferred assets. If set
+		/// below requirements, the execution may fail and assets wouldn't be
 		/// received.
 		///
 		/// `fee_item` is index of the currencies tuple that we want to use for
@@ -331,19 +331,19 @@ pub mod module {
 			currencies: Vec<(T::CurrencyId, T::Balance)>,
 			fee_item: u32,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let dest: MultiLocation = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
 
-			Self::do_transfer_multicurrencies(who, currencies, fee_item, dest, dest_weight)
+			Self::do_transfer_multicurrencies(who, currencies, fee_item, dest, dest_weight_limit)
 		}
 
 		/// Transfer several `MultiAsset` specifying the item to be used as fee
 		///
-		/// `dest_weight` is the weight for XCM execution on the dest chain, and
-		/// it would be charged from the transferred assets. If set below
-		/// requirements, the execution may fail and assets wouldn't be
+		/// `dest_weight_limit` is the weight for XCM execution on the dest
+		/// chain, and it would be charged from the transferred assets. If set
+		/// below requirements, the execution may fail and assets wouldn't be
 		/// received.
 		///
 		/// `fee_item` is index of the MultiAssets that we want to use for
@@ -360,7 +360,7 @@ pub mod module {
 			assets: Box<VersionedMultiAssets>,
 			fee_item: u32,
 			dest: Box<VersionedMultiLocation>,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let assets: MultiAssets = (*assets).try_into().map_err(|()| Error::<T>::BadVersion)?;
@@ -369,7 +369,7 @@ pub mod module {
 			// We first grab the fee
 			let fee: &MultiAsset = assets.get(fee_item as usize).ok_or(Error::<T>::AssetIndexNonExistent)?;
 
-			Self::do_transfer_multiassets(who, assets.clone(), fee.clone(), dest, dest_weight)
+			Self::do_transfer_multiassets(who, assets.clone(), fee.clone(), dest, dest_weight_limit)
 		}
 	}
 
@@ -379,7 +379,7 @@ pub mod module {
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
@@ -391,7 +391,7 @@ pub mod module {
 			);
 
 			let asset: MultiAsset = (location, amount.into()).into();
-			Self::do_transfer_multiassets(who, vec![asset.clone()].into(), asset, dest, dest_weight)
+			Self::do_transfer_multiassets(who, vec![asset.clone()].into(), asset, dest, dest_weight_limit)
 		}
 
 		fn do_transfer_with_fee(
@@ -400,7 +400,7 @@ pub mod module {
 			amount: T::Balance,
 			fee: T::Balance,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
@@ -420,16 +420,16 @@ pub mod module {
 			assets.push(asset);
 			assets.push(fee_asset.clone());
 
-			Self::do_transfer_multiassets(who, assets, fee_asset, dest, dest_weight)
+			Self::do_transfer_multiassets(who, assets, fee_asset, dest, dest_weight_limit)
 		}
 
 		fn do_transfer_multiasset(
 			who: T::AccountId,
 			asset: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
-			Self::do_transfer_multiassets(who, vec![asset.clone()].into(), asset, dest, dest_weight)
+			Self::do_transfer_multiassets(who, vec![asset.clone()].into(), asset, dest, dest_weight_limit)
 		}
 
 		fn do_transfer_multiasset_with_fee(
@@ -437,14 +437,14 @@ pub mod module {
 			asset: MultiAsset,
 			fee: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			// Push contains saturated addition, so we should be able to use it safely
 			let mut assets = MultiAssets::new();
 			assets.push(asset);
 			assets.push(fee.clone());
 
-			Self::do_transfer_multiassets(who, assets, fee, dest, dest_weight)?;
+			Self::do_transfer_multiassets(who, assets, fee, dest, dest_weight_limit)?;
 
 			Ok(())
 		}
@@ -454,7 +454,7 @@ pub mod module {
 			currencies: Vec<(T::CurrencyId, T::Balance)>,
 			fee_item: u32,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			ensure!(
 				currencies.len() <= T::MaxAssetsForTransfer::get(),
@@ -488,7 +488,7 @@ pub mod module {
 
 			let fee: MultiAsset = (fee_location, (*fee_amount).into()).into();
 
-			Self::do_transfer_multiassets(who, assets, fee, dest, dest_weight)
+			Self::do_transfer_multiassets(who, assets, fee, dest, dest_weight_limit)
 		}
 
 		fn do_transfer_multiassets(
@@ -496,7 +496,7 @@ pub mod module {
 			assets: MultiAssets,
 			fee: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
 			ensure!(
 				assets.len() <= T::MaxAssetsForTransfer::get(),
@@ -576,7 +576,7 @@ pub mod module {
 					fee_reserve,
 					&dest,
 					Some(override_recipient),
-					dest_weight.clone(),
+					dest_weight_limit.clone(),
 					true,
 				)?;
 
@@ -588,7 +588,7 @@ pub mod module {
 					non_fee_reserve,
 					&dest,
 					None,
-					dest_weight,
+					dest_weight_limit,
 					false,
 				)?;
 			} else {
@@ -599,7 +599,7 @@ pub mod module {
 					non_fee_reserve,
 					&dest,
 					None,
-					dest_weight,
+					dest_weight_limit,
 					false,
 				)?;
 			}
@@ -623,7 +623,7 @@ pub mod module {
 			reserve: Option<MultiLocation>,
 			dest: &MultiLocation,
 			maybe_recipient_override: Option<MultiLocation>,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 			use_teleport: bool,
 		) -> DispatchResult {
 			let (transfer_kind, dest, reserve, recipient) = Self::transfer_kind(reserve, dest)?;
@@ -633,11 +633,17 @@ pub mod module {
 			};
 
 			let mut msg = match transfer_kind {
-				SelfReserveAsset => Self::transfer_self_reserve_asset(assets, fee, dest, recipient, dest_weight)?,
-				ToReserve => Self::transfer_to_reserve(assets, fee, dest, recipient, dest_weight)?,
-				ToNonReserve => {
-					Self::transfer_to_non_reserve(assets, fee, reserve, dest, recipient, dest_weight, use_teleport)?
-				}
+				SelfReserveAsset => Self::transfer_self_reserve_asset(assets, fee, dest, recipient, dest_weight_limit)?,
+				ToReserve => Self::transfer_to_reserve(assets, fee, dest, recipient, dest_weight_limit)?,
+				ToNonReserve => Self::transfer_to_non_reserve(
+					assets,
+					fee,
+					reserve,
+					dest,
+					recipient,
+					dest_weight_limit,
+					use_teleport,
+				)?,
 			};
 
 			let weight = T::Weigher::weight(&mut msg).map_err(|()| Error::<T>::UnweighableMessage)?;
@@ -656,13 +662,13 @@ pub mod module {
 			fee: MultiAsset,
 			dest: MultiLocation,
 			recipient: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> Result<Xcm<T::RuntimeCall>, DispatchError> {
 			Ok(Xcm(vec![TransferReserveAsset {
 				assets: assets.clone(),
 				dest: dest.clone(),
 				xcm: Xcm(vec![
-					Self::buy_execution(fee, &dest, dest_weight)?,
+					Self::buy_execution(fee, &dest, dest_weight_limit)?,
 					Self::deposit_asset(recipient, assets.len() as u32),
 				]),
 			}]))
@@ -673,7 +679,7 @@ pub mod module {
 			fee: MultiAsset,
 			reserve: MultiLocation,
 			recipient: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> Result<Xcm<T::RuntimeCall>, DispatchError> {
 			Ok(Xcm(vec![
 				WithdrawAsset(assets.clone()),
@@ -681,7 +687,7 @@ pub mod module {
 					assets: All.into(),
 					reserve: reserve.clone(),
 					xcm: Xcm(vec![
-						Self::buy_execution(fee, &reserve, dest_weight)?,
+						Self::buy_execution(fee, &reserve, dest_weight_limit)?,
 						Self::deposit_asset(recipient, assets.len() as u32),
 					]),
 				},
@@ -694,7 +700,7 @@ pub mod module {
 			reserve: MultiLocation,
 			dest: MultiLocation,
 			recipient: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 			use_teleport: bool,
 		) -> Result<Xcm<T::RuntimeCall>, DispatchError> {
 			let mut reanchored_dest = dest.clone();
@@ -717,13 +723,13 @@ pub mod module {
 						assets: All.into(),
 						reserve: reserve.clone(),
 						xcm: Xcm(vec![
-							Self::buy_execution(half(&fee), &reserve, dest_weight.clone())?,
+							Self::buy_execution(half(&fee), &reserve, dest_weight_limit.clone())?,
 							DepositReserveAsset {
 								assets: All.into(),
 								max_assets: assets.len() as u32,
 								dest: reanchored_dest,
 								xcm: Xcm(vec![
-									Self::buy_execution(half(&fee), &dest, dest_weight)?,
+									Self::buy_execution(half(&fee), &dest, dest_weight_limit)?,
 									Self::deposit_asset(recipient, assets.len() as u32),
 								]),
 							},
@@ -737,12 +743,12 @@ pub mod module {
 						assets: All.into(),
 						reserve: reserve.clone(),
 						xcm: Xcm(vec![
-							Self::buy_execution(half(&fee), &reserve, dest_weight.clone())?,
+							Self::buy_execution(half(&fee), &reserve, dest_weight_limit.clone())?,
 							InitiateTeleport {
 								assets: All.into(),
 								dest: reanchored_dest,
 								xcm: Xcm(vec![
-									Self::buy_execution(half(&fee), &dest, dest_weight)?,
+									Self::buy_execution(half(&fee), &dest, dest_weight_limit)?,
 									Self::deposit_asset(recipient, assets.len() as u32),
 								]),
 							},
@@ -763,17 +769,14 @@ pub mod module {
 		fn buy_execution(
 			asset: MultiAsset,
 			at: &MultiLocation,
-			weight: WeightLimit,
+			weight_limit: WeightLimit,
 		) -> Result<Instruction<()>, DispatchError> {
 			let ancestry = T::LocationInverter::ancestry();
 			let fees = asset
 				.reanchored(at, &ancestry)
 				.map_err(|_| Error::<T>::CannotReanchor)?;
 
-			Ok(BuyExecution {
-				fees,
-				weight_limit: weight,
-			})
+			Ok(BuyExecution { fees, weight_limit })
 		}
 
 		/// Ensure has the `dest` has chain part and recipient part.
@@ -932,9 +935,9 @@ pub mod module {
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
-			Self::do_transfer(who, currency_id, amount, dest, dest_weight)
+			Self::do_transfer(who, currency_id, amount, dest, dest_weight_limit)
 		}
 
 		#[require_transactional]
@@ -942,9 +945,9 @@ pub mod module {
 			who: T::AccountId,
 			asset: MultiAsset,
 			dest: MultiLocation,
-			dest_weight: WeightLimit,
+			dest_weight_limit: WeightLimit,
 		) -> DispatchResult {
-			Self::do_transfer_multiasset(who, asset, dest, dest_weight)
+			Self::do_transfer_multiasset(who, asset, dest, dest_weight_limit)
 		}
 	}
 }

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -71,7 +71,7 @@ fn send_relay_chain_asset_to_relay_chain() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 500);
 	});
@@ -106,7 +106,7 @@ fn send_relay_chain_asset_to_relay_chain_with_fee() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 500);
 	});
@@ -140,7 +140,7 @@ fn cannot_lost_fund_on_send_failed() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::XcmExecutionFailed
 		);
@@ -175,7 +175,7 @@ fn send_relay_chain_asset_to_sibling() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 500);
 	});
@@ -217,7 +217,7 @@ fn send_relay_chain_asset_to_sibling_with_fee() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 500);
 	});
@@ -264,7 +264,7 @@ fn send_sibling_asset_to_reserve_sibling() {
 				)
 					.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 500);
@@ -289,7 +289,7 @@ fn send_sibling_asset_to_reserve_sibling() {
 				)
 					.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &BOB), 500);
 	});
@@ -329,7 +329,7 @@ fn send_sibling_asset_to_reserve_sibling_with_fee() {
 				)
 					.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 500);
@@ -372,7 +372,7 @@ fn send_sibling_asset_to_reserve_sibling_with_distinct_fee() {
 				)
 					.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 550);
@@ -418,7 +418,7 @@ fn send_sibling_asset_to_reserve_sibling_with_distinct_fee_index_works() {
 				)
 					.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 550);
@@ -464,7 +464,7 @@ fn send_sibling_asset_to_non_reserve_sibling() {
 				)
 				.into()
 			),
-			40
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 500);
 	});
@@ -511,7 +511,7 @@ fn send_sibling_asset_to_non_reserve_sibling_with_fee() {
 				)
 				.into()
 			),
-			40
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), 500);
 	});
@@ -553,7 +553,7 @@ fn send_self_parachain_asset_to_sibling() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &ALICE), 500);
@@ -590,7 +590,7 @@ fn send_self_parachain_asset_to_sibling_with_fee() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &ALICE), 500);
@@ -628,7 +628,7 @@ fn send_self_parachain_asset_to_sibling_with_distinct_fee() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &ALICE), 550);
@@ -681,7 +681,7 @@ fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_works() {
 				)
 					.into()
 			),
-			weight as u64,
+			WeightLimit::Limited(weight as u64),
 		));
 		assert_eq!(550, ParaTokens::free_balance(CurrencyId::C, &ALICE));
 		assert_eq!(1000 - fee_amount, ParaTokens::free_balance(CurrencyId::R, &ALICE));
@@ -741,7 +741,7 @@ fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_works_with_relative_s
 				)
 					.into()
 			),
-			weight as u64,
+			WeightLimit::Limited(weight as u64),
 		));
 		assert_eq!(550, ParaRelativeTokens::free_balance(CurrencyId::C, &ALICE));
 		assert_eq!(
@@ -804,7 +804,7 @@ fn sending_sibling_asset_to_reserve_sibling_with_relay_fee_not_enough() {
 				)
 					.into()
 			),
-			weight as u64,
+			WeightLimit::Limited(weight as u64),
 		));
 		assert_eq!(550, ParaTokens::free_balance(CurrencyId::C, &ALICE));
 		assert_eq!(1000 - fee_amount, ParaTokens::free_balance(CurrencyId::R, &ALICE));
@@ -850,7 +850,7 @@ fn transfer_asset_with_relay_fee_failed() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::InvalidAsset
 		);
@@ -874,7 +874,7 @@ fn transfer_asset_with_relay_fee_failed() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::InvalidAsset
 		);
@@ -899,7 +899,7 @@ fn transfer_asset_with_relay_fee_failed() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::FeeNotEnough
 		);
@@ -923,7 +923,7 @@ fn transfer_asset_with_relay_fee_failed() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::MinXcmFeeNotDefined
 		);
@@ -950,7 +950,7 @@ fn transfer_no_reserve_assets_fails() {
 					)
 						.into()
 				),
-				50,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::AssetHasNoReserve
 		);
@@ -979,7 +979,7 @@ fn transfer_to_self_chain_fails() {
 					)
 					.into()
 				),
-				50,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::NotCrossChainTransfer
 		);
@@ -1005,7 +1005,7 @@ fn transfer_to_invalid_dest_fails() {
 					)
 					.into()
 				),
-				50,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::InvalidDest
 		);
@@ -1137,7 +1137,7 @@ fn send_with_zero_fee_should_yield_an_error() {
 					)
 					.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::ZeroFee
 		);
@@ -1171,7 +1171,7 @@ fn send_with_insufficient_fee_traps_assets() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 	});
 
@@ -1214,7 +1214,7 @@ fn send_with_fee_should_handle_overflow() {
 					)
 					.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::XcmExecutionFailed
 		);
@@ -1264,7 +1264,7 @@ fn specifying_more_than_assets_limit_should_error() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::TooManyAssetsBeingSent
 		);
@@ -1305,7 +1305,7 @@ fn sending_non_fee_assets_with_different_reserve_should_fail() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::DistinctReserveForAssetAndFee
 		);
@@ -1341,7 +1341,7 @@ fn specifying_a_non_existent_asset_index_should_fail() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::AssetIndexNonExistent
 		);
@@ -1369,7 +1369,7 @@ fn send_with_zero_amount() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::ZeroAmount
 		);
@@ -1390,7 +1390,7 @@ fn send_with_zero_amount() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::ZeroAmount
 		);
@@ -1423,7 +1423,7 @@ fn send_self_parachain_asset_to_sibling_relative_parachain() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaRelativeTokens::free_balance(CurrencyId::D, &ALICE), 500);
@@ -1468,7 +1468,7 @@ fn send_sibling_asset_to_reserve_sibling_with_relative_view() {
 				)
 					.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::D, &ALICE), 500);
@@ -1496,7 +1496,7 @@ fn send_sibling_asset_to_reserve_sibling_with_relative_view() {
 				)
 					.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaRelativeTokens::free_balance(CurrencyId::A, &BOB), 500);
 	});
@@ -1537,7 +1537,7 @@ fn send_relative_view_sibling_asset_to_non_reserve_sibling() {
 				)
 				.into()
 			),
-			40
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::D, &ALICE), 500);
 	});
@@ -1585,7 +1585,7 @@ fn send_relay_chain_asset_to_relative_view_sibling() {
 				)
 				.into()
 			),
-			40,
+			WeightLimit::Unlimited
 		));
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), 500);
 	});
@@ -1623,7 +1623,7 @@ fn unsupported_multilocation_should_be_filtered() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::NotSupportedMultiLocation
 		);
@@ -1644,9 +1644,82 @@ fn unsupported_multilocation_should_be_filtered() {
 					)
 						.into()
 				),
-				40,
+				WeightLimit::Unlimited
 			),
 			Error::<para::Runtime>::NotSupportedMultiLocation
 		);
+	});
+}
+
+#[test]
+fn send_with_sufficient_weight_limit() {
+	TestNet::reset();
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::A, &ALICE, 1_000));
+
+		assert_ok!(ParaXTokens::transfer(
+			Some(ALICE).into(),
+			CurrencyId::A,
+			500,
+			Box::new(
+				MultiLocation::new(
+					1,
+					X2(
+						Parachain(2),
+						Junction::AccountId32 {
+							network: NetworkId::Any,
+							id: BOB.into(),
+						}
+					)
+				)
+				.into()
+			),
+			WeightLimit::Limited(40),
+		));
+
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &ALICE), 500);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &sibling_b_account()), 500);
+	});
+
+	ParaB::execute_with(|| {
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &BOB), 460);
+	});
+}
+
+#[test]
+fn send_with_insufficient_weight_limit() {
+	TestNet::reset();
+
+	ParaA::execute_with(|| {
+		assert_ok!(ParaTokens::deposit(CurrencyId::A, &ALICE, 1_000));
+
+		assert_ok!(ParaXTokens::transfer(
+			Some(ALICE).into(),
+			CurrencyId::A,
+			500,
+			Box::new(
+				MultiLocation::new(
+					1,
+					X2(
+						Parachain(2),
+						Junction::AccountId32 {
+							network: NetworkId::Any,
+							id: BOB.into(),
+						}
+					)
+				)
+				.into()
+			),
+			WeightLimit::Limited(1),
+		));
+
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &ALICE), 500);
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &sibling_b_account()), 500);
+	});
+
+	ParaB::execute_with(|| {
+		// no funds should arrive - message will have failed
+		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &BOB), 0);
 	});
 }


### PR DESCRIPTION
Closes #838.

Make the weight argument in xtokens transfers optional since in practice it's very rare to set a specific limit - most of the time people just set some arbitrary high value. With this change, you can pass `None` to set the BuyExecution limit to `Unlimited`, which is cleaner and less fragile. 