### PR TITLE
prevent nested DelayedOrigin

### DIFF
--- a/authority/Cargo.toml
+++ b/authority/Cargo.toml
@@ -12,15 +12,15 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 serde = { version = "1.0.145", optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.31" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.31" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.31" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.31" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.31" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.31" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.31" }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-preimage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 

--- a/authority/src/lib.rs
+++ b/authority/src/lib.rs
@@ -159,10 +159,10 @@ pub trait AuthorityConfig<Origin, PalletsOrigin, BlockNumber> {
 		new_delay: BlockNumber,
 	) -> DispatchResult;
 	/// Check if the `origin` is allow to delay a scheduled task that
-	/// initially created by `inital_origin`.
+	/// initially created by `initial_origin`.
 	fn check_delay_schedule(origin: Origin, initial_origin: &PalletsOrigin) -> DispatchResult;
 	/// Check if the `origin` is allow to cancel a scheduled task that
-	/// initially created by `inital_origin`.
+	/// initially created by `initial_origin`.
 	fn check_cancel_schedule(origin: Origin, initial_origin: &PalletsOrigin) -> DispatchResult;
 }
 
@@ -456,12 +456,12 @@ pub mod module {
 
 		#[pallet::weight(T::WeightInfo::remove_authorized_call())]
 		pub fn remove_authorized_call(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
-			let root_or_sigend =
+			let root_or_signed =
 				EitherOfDiverse::<EnsureRoot<T::AccountId>, EnsureSigned<T::AccountId>>::ensure_origin(origin)?;
 
 			SavedCalls::<T>::try_mutate_exists(hash, |maybe_call| {
 				let (_, maybe_caller) = maybe_call.take().ok_or(Error::<T>::CallNotAuthorized)?;
-				match root_or_sigend {
+				match root_or_signed {
 					Either::Left(_) => {} // root, do nothing
 					Either::Right(who) => {
 						// signed, ensure it's the caller

--- a/authority/src/lib.rs
+++ b/authority/src/lib.rs
@@ -11,6 +11,13 @@
 //! Two functionalities are provided by this module:
 //! - schedule a dispatchable
 //! - dispatch method with on behalf of other origins
+//!
+//! NOTE:
+//!
+//! In order to derive a feasible max encoded len for `DelayedOrigin`, it is
+//! assumed that there are no nested `DelayedOrigin` in `OriginCaller`.
+//! In practice, this means there should not be nested `schedule_dispatch`.
+//! Otherwise the proof size estimation may not be accurate.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // Disable the following three lints since they originate from an external macro

--- a/authority/src/tests.rs
+++ b/authority/src/tests.rs
@@ -698,17 +698,3 @@ fn origin_max_encoded_len_works() {
 	assert_eq!(DelayedOrigin::<u32, OriginCaller>::max_encoded_len(), 22);
 	assert_eq!(OriginCaller::max_encoded_len(), 27);
 }
-
-#[test]
-fn nested_delayed_origin_is_invalid() {
-	let orgin = DelayedOrigin::<u64, OriginCaller> {
-		delay: 1u64,
-		origin: Box::new(OriginCaller::Authority(DelayedOrigin::<u64, OriginCaller> {
-			delay: 1u64,
-			origin: Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
-		})),
-	};
-
-	let encoded = orgin.encode();
-	assert!(DelayedOrigin::<u64, OriginCaller>::decode(&mut &encoded[..]).is_err());
-}

--- a/authority/src/tests.rs
+++ b/authority/src/tests.rs
@@ -3,6 +3,7 @@
 #![cfg(test)]
 
 use super::*;
+use codec::MaxEncodedLen;
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::DispatchErrorWithPostInfo,
@@ -690,4 +691,24 @@ fn trigger_old_call_should_be_free_and_operational() {
 			})
 		);
 	});
+}
+
+#[test]
+fn origin_max_encoded_len_works() {
+	assert_eq!(DelayedOrigin::<u32, OriginCaller>::max_encoded_len(), 22);
+	assert_eq!(OriginCaller::max_encoded_len(), 27);
+}
+
+#[test]
+fn nested_delayed_origin_is_invalid() {
+	let orgin = DelayedOrigin::<u64, OriginCaller> {
+		delay: 1u64,
+		origin: Box::new(OriginCaller::Authority(DelayedOrigin::<u64, OriginCaller> {
+			delay: 1u64,
+			origin: Box::new(OriginCaller::system(frame_system::RawOrigin::Root)),
+		})),
+	};
+
+	let encoded = orgin.encode();
+	assert!(OriginCaller::decode(&mut &encoded[..]).is_err());
 }

--- a/authority/src/tests.rs
+++ b/authority/src/tests.rs
@@ -710,5 +710,5 @@ fn nested_delayed_origin_is_invalid() {
 	};
 
 	let encoded = orgin.encode();
-	assert!(OriginCaller::decode(&mut &encoded[..]).is_err());
+	assert!(DelayedOrigin::<u64, OriginCaller>::decode(&mut &encoded[..]).is_err());
 }


### PR DESCRIPTION
Fixes https://substrate.stackexchange.com/questions/5970/implement-maxencodedlen-for-nested-origin

One issue is that this make decode invalid but it is still possible to construct nested DelayedOrigin normally.
This means the storage will be inconsistent if someone is ever successfully wrote origin containing nested DelayedOrigin. The read will fail.

Maybe the safer way is not making decoding nested DelayedOrigin invalid. Just guarded enough so ensure it cannot be constructed but even it does, it is not a state consistency error but _just_ a PoV size estimation issue.