### PR TITLE
Changed `vested_transfer` extrinsic behavior.

### DIFF
--- a/vesting/src/lib.rs
+++ b/vesting/src/lib.rs
@@ -264,6 +264,14 @@ pub mod module {
 		) -> DispatchResult {
 			let from = T::VestedTransferOrigin::ensure_origin(origin)?;
 			let to = T::Lookup::lookup(dest)?;
+
+			if to == from {
+				ensure!(
+					T::Currency::free_balance(&from) >= schedule.total_amount().ok_or(ArithmeticError::Overflow)?,
+					Error::<T>::InsufficientBalanceToLock,
+				);
+			}
+
 			Self::do_vested_transfer(&from, &to, schedule.clone())?;
 
 			Self::deposit_event(Event::VestingScheduleAdded {

--- a/vesting/src/mock.rs
+++ b/vesting/src/mock.rs
@@ -116,6 +116,9 @@ pub const ALICE: AccountId = 1;
 pub const BOB: AccountId = 2;
 pub const CHARLIE: AccountId = 3;
 
+pub const ALICE_BALANCE: u64 = 100;
+pub const CHARLIE_BALANCE: u64 = 50;
+
 #[derive(Default)]
 pub struct ExtBuilder;
 
@@ -126,7 +129,7 @@ impl ExtBuilder {
 			.unwrap();
 
 		pallet_balances::GenesisConfig::<Runtime> {
-			balances: vec![(ALICE, 100), (CHARLIE, 50)],
+			balances: vec![(ALICE, ALICE_BALANCE), (CHARLIE, CHARLIE_BALANCE)],
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();


### PR DESCRIPTION
Fixed self-vesting case (`from` == `to`) when it was possible to self-freeze funds above the current account balance.