### PR TITLE
feat: MinXcmFee from storage

### DIFF
--- a/asset-registry/src/mock/para.rs
+++ b/asset-registry/src/mock/para.rs
@@ -336,6 +336,7 @@ impl orml_xtokens::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type ReserveProvider = RelativeReserveProvider;
+	type WeightInfo = ();
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -254,6 +254,7 @@ impl orml_xtokens::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type ReserveProvider = AbsoluteReserveProvider;
+	type WeightInfo = ();
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -326,6 +326,7 @@ impl orml_xtokens::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type ReserveProvider = RelativeReserveProvider;
+	type WeightInfo = ();
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/para_teleport.rs
+++ b/xtokens/src/mock/para_teleport.rs
@@ -245,6 +245,7 @@ impl orml_xtokens::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type ReserveProvider = AbsoluteReserveProvider;
+	type WeightInfo = ();
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/weights.rs
+++ b/xtokens/src/weights.rs
@@ -1,0 +1,23 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+#![allow(clippy::unnecessary_cast)]
+
+use frame_support::{
+	traits::Get,
+	weights::{constants::RocksDbWeight, Weight},
+};
+use sp_std::marker::PhantomData;
+
+pub trait WeightInfo {
+	fn set_minimum_execution_fee() -> Weight;
+}
+
+/// Default weights.
+impl WeightInfo for () {
+	fn set_minimum_execution_fee() -> Weight {
+        // ref_time guesstimated by the tokens::set_balance ref_time 
+            Weight::from_ref_time(34_000_000)
+                .saturating_add(RocksDbWeight::get().writes(1 as u64))
+	}
+}


### PR DESCRIPTION
Allows you to store the MinXcmFee in storage. The advantage of this is that no runtime upgrade is required when you want to update this value. Usage for existing consumers is unchanged, other than having to provide `type WeightInfo = ();` now. To opt in into fetching the value from storage, users can use `type MinXcmFee = XTokens;`.