### PR TITLE
feat: derive MEL for Value enum

### DIFF
--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -8,8 +8,6 @@ use sp_std::{
 	prelude::Vec,
 };
 
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
 pub use asset_registry::{FixedConversionRateProvider, WeightToFeeConverter};
 pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
 pub use currency::{
@@ -24,6 +22,8 @@ pub use nft::InspectExtended;
 pub use price::{DefaultPriceProvider, PriceProvider};
 pub use rewards::RewardHandler;
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 pub use xcm_transfer::XcmTransfer;
 
 pub mod arithmetic;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use impl_trait_for_tuples::impl_for_tuples;
 use sp_runtime::{DispatchResult, RuntimeDebug};
 use sp_std::{
@@ -10,7 +10,6 @@ use sp_std::{
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-
 pub use asset_registry::{FixedConversionRateProvider, WeightToFeeConverter};
 pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
 pub use currency::{
@@ -58,7 +57,7 @@ pub trait CombineData<Key, TimestampedValue> {
 }
 
 /// Indicate if should change a value
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum Change<Value> {
 	/// No change.
 	NoChange,


### PR DESCRIPTION
Derives `MaxEncodedLen` for `Value` enum. Without this change, components which make use of `Value` cannot derive `MaxEncodedLen` automatically.