### PR TITLE
Add BenchmarkError::Weightless (for v0.9.36)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2022-08-05
+          toolchain: nightly-2022-10-30
           components: rustfmt
           target: wasm32-unknown-unknown
       - name: Generate code coverage

--- a/.github/workflows/master.yml.disabled
+++ b/.github/workflows/master.yml.disabled
@@ -15,7 +15,7 @@ jobs:
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly-2022-08-05
+        toolchain: nightly-2022-10-30
     - name: Install cargo-unleash
       run: cargo install cargo-unleash --git https://github.com/xlc/cargo-unleash.git # https://github.com/paritytech/cargo-unleash/pull/38
     - name: Prepare

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly-2022-08-05
+        toolchain: nightly-2022-10-30
         components: rustfmt
         target: wasm32-unknown-unknown
     - name: Install Wasm toolchain

--- a/Cargo.dev.toml
+++ b/Cargo.dev.toml
@@ -4,6 +4,7 @@ members = [
 	"auction",
 	"authority",
 	"bencher",
+	"bencher/test",
 	"benchmarking",
 	"currencies",
 	"gradually-update",
@@ -25,6 +26,8 @@ members = [
 	"weight-meter",
 	"payments"
 ]
+
+exclude = ["bencher/test"]
 
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,11 @@ dev-check: Cargo.toml check
 
 dev-check-tests: Cargo.toml
 	cargo check --tests --all
+	cargo check --tests --features=bench --package=orml-weight-meter --package=orml-bencher-test
 
 dev-test: Cargo.toml
-	cargo test --all --features runtime-benchmarks
+	cargo test --all --features=runtime-benchmarks
+	cargo test --features=bench --package=orml-weight-meter --package=orml-bencher-test
 
 # run benchmarks via Acala node
 benchmark-all:

--- a/asset-registry/src/lib.rs
+++ b/asset-registry/src/lib.rs
@@ -313,7 +313,7 @@ impl<T: Config> Pallet<T> {
 	fn do_insert_location(asset_id: T::AssetId, location: VersionedMultiLocation) -> DispatchResult {
 		// if the metadata contains a location, set the LocationToAssetId
 		let location: MultiLocation = location.try_into().map_err(|()| Error::<T>::BadVersion)?;
-		LocationToAssetId::<T>::try_mutate(&location, |maybe_asset_id| {
+		LocationToAssetId::<T>::try_mutate(location, |maybe_asset_id| {
 			ensure!(maybe_asset_id.is_none(), Error::<T>::ConflictingLocation);
 			*maybe_asset_id = Some(asset_id);
 			Ok(())

--- a/auction/src/lib.rs
+++ b/auction/src/lib.rs
@@ -109,12 +109,12 @@ pub mod module {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
 		fn on_initialize(now: T::BlockNumber) -> Weight {
-			T::WeightInfo::on_finalize(AuctionEndTime::<T>::iter_prefix(&now).count() as u32)
+			T::WeightInfo::on_finalize(AuctionEndTime::<T>::iter_prefix(now).count() as u32)
 		}
 
 		fn on_finalize(now: T::BlockNumber) {
-			for (auction_id, _) in AuctionEndTime::<T>::drain_prefix(&now) {
-				if let Some(auction) = Auctions::<T>::take(&auction_id) {
+			for (auction_id, _) in AuctionEndTime::<T>::drain_prefix(now) {
+				if let Some(auction) = Auctions::<T>::take(auction_id) {
 					T::Handler::on_auction_ended(auction_id, auction.bid);
 				}
 			}
@@ -151,10 +151,10 @@ pub mod module {
 				match bid_result.auction_end_change {
 					Change::NewValue(new_end) => {
 						if let Some(old_end_block) = auction.end {
-							AuctionEndTime::<T>::remove(&old_end_block, id);
+							AuctionEndTime::<T>::remove(old_end_block, id);
 						}
 						if let Some(new_end_block) = new_end {
-							AuctionEndTime::<T>::insert(&new_end_block, id, ());
+							AuctionEndTime::<T>::insert(new_end_block, id, ());
 						}
 						auction.end = new_end;
 					}
@@ -189,10 +189,10 @@ impl<T: Config> Auction<T::AccountId, T::BlockNumber> for Pallet<T> {
 	) -> DispatchResult {
 		let auction = Auctions::<T>::get(id).ok_or(Error::<T>::AuctionNotExist)?;
 		if let Some(old_end) = auction.end {
-			AuctionEndTime::<T>::remove(&old_end, id);
+			AuctionEndTime::<T>::remove(old_end, id);
 		}
 		if let Some(new_end) = info.end {
-			AuctionEndTime::<T>::insert(&new_end, id, ());
+			AuctionEndTime::<T>::insert(new_end, id, ());
 		}
 		Auctions::<T>::insert(id, info);
 		Ok(())
@@ -211,14 +211,14 @@ impl<T: Config> Auction<T::AccountId, T::BlockNumber> for Pallet<T> {
 			})?;
 		Auctions::<T>::insert(auction_id, auction);
 		if let Some(end_block) = end {
-			AuctionEndTime::<T>::insert(&end_block, auction_id, ());
+			AuctionEndTime::<T>::insert(end_block, auction_id, ());
 		}
 
 		Ok(auction_id)
 	}
 
 	fn remove_auction(id: Self::AuctionId) {
-		if let Some(auction) = Auctions::<T>::take(&id) {
+		if let Some(auction) = Auctions::<T>::take(id) {
 			if let Some(end_block) = auction.end {
 				AuctionEndTime::<T>::remove(end_block, id);
 			}

--- a/bencher/Cargo.toml
+++ b/bencher/Cargo.toml
@@ -10,15 +10,15 @@ edition = "2021"
 [dependencies]
 paste = "1.0.7"
 build-helper = { version = "0.1.1", optional = true }
-cargo_metadata = { version = "0.14.1", optional = true }
+cargo_metadata = { version = "0.15.2", optional = true }
 tempfile = { version = "3.2.0", optional = true }
 toml = { version = "0.5.8", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 ansi_term = { version = "0.12.1", optional = true }
 wasm-gc-api = { version = "0.1.11", optional = true }
 rand = {version = "0.8.3", optional = true }
-linregress = { version = "0.4.4", optional = true }
-parking_lot = { version = "0.12.0", optional = true }
+linregress = { version = "0.5.0", optional = true }
+parking_lot = { version = "0.12.1", optional = true }
 thiserror = { version = "1.0", optional = true }
 serde = { version = "1.0.136", optional = true, features = ['derive'] }
 serde_json = {version = "1.0.68", optional = true }
@@ -35,7 +35,7 @@ sc-executor = { git = "https://github.com/paritytech/substrate", default-feature
 sc-executor-common = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v0.9.36" }
 sc-client-db = { git = "https://github.com/paritytech/substrate", default-features = false, features = ["rocksdb"], optional = true , branch = "polkadot-v0.9.36" }
 sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.36" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
 sp-externalities = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.36" }
 sp-storage = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.36" }
 
@@ -67,7 +67,7 @@ std = [
     "sc-executor-common",
     "sc-client-db",
     "sp-maybe-compressed-blob",
-    "frame-benchmarking/std",
+    "frame-support/std",
     "sp-externalities/std",
     "sp-storage/std",
 ]

--- a/bencher/src/bench_runner.rs
+++ b/bencher/src/bench_runner.rs
@@ -2,18 +2,14 @@ use super::{
 	bench_ext::BenchExt,
 	tracker::{BenchTracker, BenchTrackerExt},
 };
-use frame_benchmarking::frame_support::sp_runtime::traits::Block;
+use frame_support::sp_runtime::traits::Block;
 use sc_executor::{WasmExecutionMethod, WasmExecutor, WasmtimeInstantiationStrategy};
 use sc_executor_common::runtime_blob::RuntimeBlob;
 use sp_externalities::Extensions;
 use sp_state_machine::{Ext, OverlayedChanges, StorageTransactionCache};
 use sp_std::sync::Arc;
 
-type ComposeHostFunctions = (
-	sp_io::SubstrateHostFunctions,
-	frame_benchmarking::benchmarking::HostFunctions,
-	super::bench::HostFunctions,
-);
+type ComposeHostFunctions = (sp_io::SubstrateHostFunctions, super::bench::HostFunctions);
 
 /// Run benches
 pub fn run<B: Block>(wasm_code: Vec<u8>) -> std::result::Result<Vec<u8>, sc_executor_common::error::Error> {

--- a/bencher/src/bencher.rs
+++ b/bencher/src/bencher.rs
@@ -40,8 +40,8 @@ impl Bencher {
 	pub fn before_run(&self) {
 		#[cfg(not(feature = "std"))]
 		{
-			frame_benchmarking::benchmarking::commit_db();
-			frame_benchmarking::benchmarking::wipe_db();
+			crate::bench::commit_db();
+			crate::bench::wipe_db();
 		}
 	}
 
@@ -56,8 +56,8 @@ impl Bencher {
 	{
 		#[cfg(not(feature = "std"))]
 		{
-			frame_benchmarking::benchmarking::commit_db();
-			frame_benchmarking::benchmarking::reset_read_write_count();
+			crate::bench::commit_db();
+			crate::bench::reset_read_write_count();
 			crate::bench::start_timer();
 		}
 
@@ -68,7 +68,7 @@ impl Bencher {
 			let elapsed = crate::bench::end_timer().saturating_sub(crate::bench::redundant_time());
 			self.current.elapses.push(elapsed);
 
-			frame_benchmarking::benchmarking::commit_db();
+			crate::bench::commit_db();
 
 			// changed keys
 			self.current.keys = crate::bench::read_written_keys();

--- a/bencher/src/build_wasm/prerequisites.rs
+++ b/bencher/src/build_wasm/prerequisites.rs
@@ -77,11 +77,7 @@ fn get_rustup_nightly(selected: Option<String>) -> Option<CargoCommand> {
 	let version = match selected {
 		Some(selected) => selected,
 		None => {
-			let output = Command::new("rustup")
-				.args(&["toolchain", "list"])
-				.output()
-				.ok()?
-				.stdout;
+			let output = Command::new("rustup").args(["toolchain", "list"]).output().ok()?.stdout;
 			let lines = output.as_slice().lines();
 
 			let mut latest_nightly = None;
@@ -194,7 +190,7 @@ fn create_check_toolchain_project(project_dir: &Path) {
 	let manifest_path = project_dir.join("Cargo.toml");
 
 	write_file_if_changed(
-		&manifest_path,
+		manifest_path,
 		r#"
 			[package]
 			name = "wasm-test"
@@ -260,7 +256,7 @@ fn check_wasm_toolchain_installed(cargo_command: CargoCommand) -> Result<CargoCo
 	let manifest_path = temp.path().join("Cargo.toml").display().to_string();
 
 	let mut build_cmd = cargo_command.command();
-	build_cmd.args(&[
+	build_cmd.args([
 		"build",
 		"--target=wasm32-unknown-unknown",
 		"--manifest-path",
@@ -272,7 +268,7 @@ fn check_wasm_toolchain_installed(cargo_command: CargoCommand) -> Result<CargoCo
 	}
 
 	let mut run_cmd = cargo_command.command();
-	run_cmd.args(&["run", "--manifest-path", &manifest_path]);
+	run_cmd.args(["run", "--manifest-path", &manifest_path]);
 
 	build_cmd.output().map_err(|_| err_msg.clone()).and_then(|s| {
 		if s.status.success() {

--- a/bencher/src/build_wasm/wasm_project.rs
+++ b/bencher/src/build_wasm/wasm_project.rs
@@ -428,7 +428,7 @@ fn build_project(project: &Path, default_rustflags: &str, cargo_cmd: CargoComman
 	);
 
 	build_cmd
-		.args(&["rustc", "--target=wasm32-unknown-unknown"])
+		.args(["rustc", "--target=wasm32-unknown-unknown"])
 		.arg(format!("--manifest-path={}", manifest_path.display()))
 		.env("RUSTFLAGS", rustflags)
 		// Unset the `CARGO_TARGET_DIR` to prevent a cargo deadlock (cargo locks a target dir exclusive).

--- a/bencher/src/handler.rs
+++ b/bencher/src/handler.rs
@@ -3,7 +3,7 @@ use crate::{
 	BenchResult,
 };
 use codec::Decode;
-use frame_benchmarking::frame_support::traits::StorageInfo;
+use frame_support::traits::StorageInfo;
 use linregress::{FormulaRegressionBuilder, RegressionDataBuilder};
 use serde::{Deserialize, Serialize};
 use sp_core::hexdisplay::HexDisplay;
@@ -66,14 +66,13 @@ pub fn handle(output: Vec<u8>, storage_infos: Vec<StorageInfo>) {
 
 			comments.sort();
 
+			let intercepted_value = model.parameters()[0] as u64;
+
 			println!(
 				"{} {:<40} {:>20} storage: {:<20}",
 				green_bold("Bench"),
 				cyan(&name),
-				green_bold(&format!(
-					"{:?}",
-					Duration::from_nanos(model.parameters.intercept_value as u64)
-				)),
+				green_bold(&format!("{:?}", Duration::from_nanos(intercepted_value))),
 				green_bold(&format!(
 					"[r: {}, w: {}]",
 					&total_reads.to_string(),
@@ -83,7 +82,7 @@ pub fn handle(output: Vec<u8>, storage_infos: Vec<StorageInfo>) {
 
 			BenchData {
 				name,
-				weight: model.parameters.intercept_value as u64 * 1_000,
+				weight: intercepted_value * 1_000,
 				reads: total_reads,
 				writes: total_writes,
 				comments,

--- a/bencher/src/lib.rs
+++ b/bencher/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
-pub extern crate frame_benchmarking;
+pub extern crate frame_support;
 #[doc(hidden)]
 pub extern crate paste;
 #[doc(hidden)]

--- a/bencher/src/macros.rs
+++ b/bencher/src/macros.rs
@@ -125,7 +125,7 @@ macro_rules! run_benches {
     ) => {
 		#[cfg(all(feature = "std", feature = "bench"))]
 		pub fn main() -> std::io::Result<()> {
-			use $crate::frame_benchmarking::frame_support::traits::StorageInfoTrait;
+			use $crate::frame_support::traits::StorageInfoTrait;
 			let wasm = $crate::build_wasm::build()?;
 			let storage_info = $all_pallets_with_system::storage_info();
 			match $crate::bench_runner::run::<$block>(wasm) {

--- a/bencher/src/utils.rs
+++ b/bencher/src/utils.rs
@@ -36,6 +36,18 @@ pub trait Bench {
 		println!("{}", msg);
 	}
 
+	fn commit_db(&mut self) {
+		self.commit()
+	}
+
+	fn wipe_db(&mut self) {
+		self.wipe()
+	}
+
+	fn reset_read_write_count(&mut self) {
+		self.reset_read_write_count()
+	}
+
 	fn start_timer(&mut self) {
 		let tracker = &***self
 			.extension::<BenchTrackerExt>()

--- a/bencher/test/Cargo.toml
+++ b/bencher/test/Cargo.toml
@@ -32,18 +32,15 @@ std = [
     "serde",
     "scale-info/std",
     "codec/std",
-    "orml-bencher/std",
     "frame-support/std",
     "frame-system/std",
     "sp-runtime/std",
-    "sp-std/std",
     "sp-core/std",
+    "sp-std/std",
+    "orml-bencher/std",
     "orml-weight-meter/std",
 ]
 bench = [
     "orml-bencher/bench",
     "orml-weight-meter/bench",
-    "frame-support/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
 ]

--- a/bencher/test/src/benches.rs
+++ b/bencher/test/src/benches.rs
@@ -42,10 +42,4 @@ fn whitelist(b: &mut Bencher) {
 	});
 }
 
-benches!(
-	whitelist,
-	set_value,
-	set_foo,
-	remove_all_bar,
-	remove_all_bar_with_limit
-);
+benches!(whitelist, set_value, set_foo, remove_all_bar, remove_all_bar_with_limit);

--- a/bencher/test/src/lib.rs
+++ b/bencher/test/src/lib.rs
@@ -40,9 +40,9 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
-		#[orml_weight_meter::start(ModuleWeights::<T>::set_value())]
+		#[orml_weight_meter::start(ModuleWeights::<T>::set_value().ref_time())]
 		pub fn set_value(origin: OriginFor<T>, n: u32) -> DispatchResultWithPostInfo {
-			let _sender = frame_system::ensure_signed(origin)?;
+			frame_system::ensure_signed(origin)?;
 			Value::<T>::get();
 			Value::<T>::put(n);
 			Value::<T>::put(n + 1);
@@ -53,14 +53,14 @@ pub mod pallet {
 		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
-			let _sender = frame_system::ensure_none(origin)?;
+			frame_system::ensure_none(origin)?;
 			Foo::<T>::put(1);
 			Ok(())
 		}
 	}
 
 	impl<T: Config> Pallet<T> {
-		#[orml_weight_meter::weight(ModuleWeights::<T>::set_foo())]
+		#[orml_weight_meter::weight(ModuleWeights::<T>::set_foo().ref_time())]
 		pub(crate) fn set_foo() -> frame_support::dispatch::DispatchResult {
 			Value::<T>::put(2);
 

--- a/bencher/test/src/mock.rs
+++ b/bencher/test/src/mock.rs
@@ -16,7 +16,7 @@ pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 
 pub type SignedExtra = (frame_system::CheckWeight<Runtime>,);
 
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 
 pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
 

--- a/bencher/test/src/weights.rs
+++ b/bencher/test/src/weights.rs
@@ -12,11 +12,19 @@ pub struct ModuleWeights<T>(PhantomData<T>);
 impl<T: frame_system::Config> ModuleWeights<T> {
 	// Storage access info
 	//
+	// Test::Bar (r: 0, w: 1)
+	pub fn whitelist() -> Weight {
+		Weight::from_ref_time(5_356_000)
+			.saturating_add(T::DbWeight::get().writes(1))
+	}
+	// Storage access info
+	//
 	// Test::Value (r: 1, w: 1)
+	// Unknown 0x3a7472616e73616374696f6e5f6c6576656c3a (r: 1, w: 1)
 	pub fn set_value() -> Weight {
-		(5_236_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(3_919_000)
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
 	}
 	// Storage access info
 	//
@@ -24,13 +32,20 @@ impl<T: frame_system::Config> ModuleWeights<T> {
 	// Test::Foo (r: 0, w: 1)
 	// Test::Value (r: 0, w: 1)
 	pub fn set_foo() -> Weight {
-		(13_274_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(5_133_000)
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(4))
 	}
 	// Storage access info
 	//
 	pub fn remove_all_bar() -> Weight {
-		(3_449_000 as Weight)
+		Weight::from_ref_time(1_533_000)
+	}
+	// Storage access info
+	//
+	// Test::Bar (r: 0, w: 10)
+	pub fn remove_all_bar_with_limit() -> Weight {
+		Weight::from_ref_time(1_600_000)
+			.saturating_add(T::DbWeight::get().writes(10))
 	}
 }

--- a/benchmarking/src/lib.rs
+++ b/benchmarking/src/lib.rs
@@ -1180,6 +1180,14 @@ macro_rules! impl_benchmark_test_suite {
 											$crate::str::from_utf8(benchmark_name)
 												.expect("benchmark name is always a valid string!"),
 										);
+									},
+									$crate::BenchmarkError::Weightless => {
+										// This is considered a success condition.
+										$crate::log::error!(
+											"WARNING: benchmark error weightless skipped - {}",
+											$crate::str::from_utf8(benchmark_name)
+												.expect("benchmark name is always a valid string!"),
+										);
 									}
 								}
 							},
@@ -1310,6 +1318,14 @@ macro_rules! add_benchmark {
 				Err($crate::BenchmarkError::Skip) => {
 					$crate::log::error!(
 						"WARNING: benchmark error skipped - {}",
+						$crate::str::from_utf8(benchmark)
+							.expect("benchmark name is always a valid string!")
+					);
+					None
+				},
+				Err($crate::BenchmarkError::Weightless) => {
+					$crate::log::error!(
+						"WARNING: benchmark weightless skipped - {}",
 						$crate::str::from_utf8(benchmark)
 							.expect("benchmark name is always a valid string!")
 					);

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -215,7 +215,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				value: value.clone(),
 				timestamp: now,
 			};
-			RawValues::<T, I>::insert(&who, &key, timestamped);
+			RawValues::<T, I>::insert(&who, key, timestamped);
 
 			// Update `Values` storage if `combined` yielded result.
 			if let Some(combined) = Self::combined(key) {

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -1,15 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use impl_trait_for_tuples::impl_for_tuples;
 use sp_runtime::{DispatchResult, RuntimeDebug};
 use sp_std::{
 	cmp::{Eq, PartialEq},
 	prelude::Vec,
 };
-
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
 
 pub use asset_registry::{FixedConversionRateProvider, WeightToFeeConverter};
 pub use auction::{Auction, AuctionHandler, AuctionInfo, OnNewBidResult};
@@ -25,6 +22,8 @@ pub use nft::InspectExtended;
 pub use price::{DefaultPriceProvider, PriceProvider};
 pub use rewards::RewardHandler;
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 pub use xcm_transfer::XcmTransfer;
 
 pub mod arithmetic;
@@ -58,7 +57,7 @@ pub trait CombineData<Key, TimestampedValue> {
 }
 
 /// Indicate if should change a value
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum Change<Value> {
 	/// No change.
 	NoChange,

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -19,4 +19,13 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		dest: MultiLocation,
 		dest_weight_limit: WeightLimit,
 	) -> DispatchResult;
+
+	/// Transfer `MultiAssetWithFee`
+	fn transfer_multiasset_with_fee(
+		who: AccountId,
+		asset: MultiAsset,
+		fee: MultiAsset,
+		dest: MultiLocation,
+		dest_weight_limit: WeightLimit,
+	) -> DispatchResult;
 }

--- a/vesting/src/lib.rs
+++ b/vesting/src/lib.rs
@@ -245,7 +245,7 @@ pub mod module {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::claim((<T as Config>::MaxVestingSchedules::get() / 2) as u32))]
+		#[pallet::weight(T::WeightInfo::claim(<T as Config>::MaxVestingSchedules::get() / 2))]
 		pub fn claim(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let locked_amount = Self::do_claim(&who);
@@ -301,7 +301,7 @@ pub mod module {
 		}
 
 		#[pallet::call_index(3)]
-		#[pallet::weight(T::WeightInfo::claim((<T as Config>::MaxVestingSchedules::get() / 2) as u32))]
+		#[pallet::weight(T::WeightInfo::claim(<T as Config>::MaxVestingSchedules::get() / 2))]
 		pub fn claim_for(origin: OriginFor<T>, dest: <T::Lookup as StaticLookup>::Source) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
 			let who = T::Lookup::lookup(dest)?;

--- a/weight-gen/src/main.rs
+++ b/weight-gen/src/main.rs
@@ -162,7 +162,7 @@ fn main() {
 	// Use empty header if a header path is not given.
 	let header = {
 		if let Some(path) = matches.get_one::<String>("header") {
-			::std::fs::read_to_string(&path).expect("Header file not found")
+			::std::fs::read_to_string(path).expect("Header file not found")
 		} else {
 			String::from("")
 		}
@@ -175,7 +175,7 @@ fn main() {
 	// Use default template if template path is not given.
 	let template = {
 		if let Some(path) = matches.get_one::<String>("template") {
-			::std::fs::read_to_string(&path).expect("Template file not found")
+			::std::fs::read_to_string(path).expect("Template file not found")
 		} else {
 			String::from(DEFAULT_TEMPLATE)
 		}
@@ -183,7 +183,7 @@ fn main() {
 
 	// Write benchmark to file or print to terminal if output path is not given.
 	if let Some(path) = matches.get_one::<String>("output") {
-		let mut output_file = ::std::fs::File::create(&path).expect("Could not create output file");
+		let mut output_file = ::std::fs::File::create(path).expect("Could not create output file");
 
 		handlebars
 			.render_template_to_write(&template, &hbs_data, &mut output_file)

--- a/weight-meter/Cargo.toml
+++ b/weight-meter/Cargo.toml
@@ -24,6 +24,8 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36" }
 
+orml-bencher = { path = "../bencher" }
+
 [features]
 default = ["std"]
 std = [

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -924,10 +924,8 @@ pub mod module {
 		fn get_reserve_location(assets: &MultiAssets, fee_item: &u32) -> Option<MultiLocation> {
 			let reserve_idx = if assets.len() == 1 {
 				0
-			} else if *fee_item == 0 {
-				1
 			} else {
-				0
+				(*fee_item == 0) as usize
 			};
 			let asset = assets.get(reserve_idx);
 			asset.and_then(T::ReserveProvider::reserve)

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -953,6 +953,17 @@ pub mod module {
 		) -> DispatchResult {
 			Self::do_transfer_multiasset(who, asset, dest, dest_weight_limit)
 		}
+
+		#[require_transactional]
+		fn transfer_multiasset_with_fee(
+			who: T::AccountId,
+			asset: MultiAsset,
+			fee: MultiAsset,
+			dest: MultiLocation,
+			dest_weight_limit: WeightLimit,
+		) -> DispatchResult {
+			Self::do_transfer_multiasset_with_fee(who, asset, fee, dest, dest_weight_limit)
+		}
 	}
 }
 


### PR DESCRIPTION
this was already in polkadot release v0.9.36 so should be added to the release branch in ORML. Otherwise some benchmarks fail to build. The change must've been missed in the 0.9.36 update PR

![Screenshot 2023-01-16 at 15 05 09](https://user-images.githubusercontent.com/6452260/212758010-2e23d433-8f0f-4e61-9683-f9fd7b1ab7ed.png)
