### PR TITLE
Add BenchmarkError::Weightless (for v0.9.36)

### DIFF
--- a/benchmarking/src/lib.rs
+++ b/benchmarking/src/lib.rs
@@ -1180,6 +1180,14 @@ macro_rules! impl_benchmark_test_suite {
 											$crate::str::from_utf8(benchmark_name)
 												.expect("benchmark name is always a valid string!"),
 										);
+									},
+									$crate::BenchmarkError::Weightless => {
+										// This is considered a success condition.
+										$crate::log::error!(
+											"WARNING: benchmark error weightless skipped - {}",
+											$crate::str::from_utf8(benchmark_name)
+												.expect("benchmark name is always a valid string!"),
+										);
 									}
 								}
 							},
@@ -1310,6 +1318,14 @@ macro_rules! add_benchmark {
 				Err($crate::BenchmarkError::Skip) => {
 					$crate::log::error!(
 						"WARNING: benchmark error skipped - {}",
+						$crate::str::from_utf8(benchmark)
+							.expect("benchmark name is always a valid string!")
+					);
+					None
+				},
+				Err($crate::BenchmarkError::Weightless) => {
+					$crate::log::error!(
+						"WARNING: benchmark weightless skipped - {}",
 						$crate::str::from_utf8(benchmark)
 							.expect("benchmark name is always a valid string!")
 					);


### PR DESCRIPTION
this was already in polkadot release v0.9.36 so should be added to the release branch in ORML. Otherwise some benchmarks fail to build. The change must've been missed in the 0.9.36 update PR

![Screenshot 2023-01-16 at 15 05 09](https://user-images.githubusercontent.com/6452260/212758010-2e23d433-8f0f-4e61-9683-f9fd7b1ab7ed.png)