### PR TITLE
Update jsonrpsee 0.16.2

### DIFF
--- a/Cargo.dev.toml
+++ b/Cargo.dev.toml
@@ -12,6 +12,8 @@ members = [
 	"oracle/rpc",
 	"oracle/rpc/runtime-api",
 	"tokens",
+	"tokens/rpc",
+	"tokens/rpc/runtime-api",
 	"traits",
 	"utilities",
 	"vesting",

--- a/oracle/rpc/Cargo.toml
+++ b/oracle/rpc/Cargo.toml
@@ -8,7 +8,7 @@ description = "RPC module for orml-oracle."
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
+jsonrpsee = { version = "0.16.2", features = ["client", "server", "macros"] }
 tracing = { version = "0.1.29" }
 tracing-core = { version = "0.1.28" }
 

--- a/oracle/rpc/Cargo.toml
+++ b/oracle/rpc/Cargo.toml
@@ -8,7 +8,7 @@ description = "RPC module for orml-oracle."
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
+jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 tracing = { version = "0.1.29" }
 tracing-core = { version = "0.1.28" }
 

--- a/tokens/rpc/Cargo.toml
+++ b/tokens/rpc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
+jsonrpsee = { version = "0.16.2", features = ["client", "server", "macros"] }
 tracing = { version = "0.1.29" }
 tracing-core = { version = "0.1.28" }
 

--- a/tokens/rpc/Cargo.toml
+++ b/tokens/rpc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
+jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 tracing = { version = "0.1.29" }
 tracing-core = { version = "0.1.28" }
 


### PR DESCRIPTION
```
   --> rpc/src/lib.rs:89:15
    |
89  |     module.merge(Tokens::new(client.clone()).into_rpc())?;
    |            ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<jsonrpsee_core::server::rpc_module::RpcModule<Tokens<C, sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u32, sp_runtime::traits::BlakeTwo2
56>, UncheckedExtrinsic>>>>` is not implemented for `Methods`
    |            |
    |            required by a bound introduced by this call
    |
    = help: the trait `From<RpcModule<Context>>` is implemented for `Methods`
    = note: required for `jsonrpsee_core::server::rpc_module::RpcModule<Tokens<C, sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u32, sp_runtime::traits::BlakeTwo256>, UncheckedExtrinsic>>>` to implement `Into<Metho
ds>`
```