### PR TITLE
Add lock events to tokens pallet

### DIFF
--- a/scripts/run-clippy.sh
+++ b/scripts/run-clippy.sh
@@ -6,7 +6,7 @@ COMMAND=$1
 
 ALLOW_CLIPPY_RULES=(
 	"clippy::identity_op" # this helps the code to be consistant
-	"clippy::blacklisted-name" # TODO: allow them in test only
+	"clippy::disallowed_names" # TODO: allow them in test only
 	"clippy::ptr-arg" # TODO: decide if we want to fix those
 	"clippy::match_single_binding" # TODO: fix those
 )

--- a/tokens/src/tests.rs
+++ b/tokens/src/tests.rs
@@ -8,12 +8,6 @@ use frame_system::RawOrigin;
 use mock::*;
 use sp_runtime::{traits::BadOrigin, TokenError};
 
-fn events() -> Vec<Event> {
-	let evt = System::events().into_iter().map(|evt| evt.event).collect::<Vec<_>>();
-	System::reset_events();
-	evt
-}
-
 // *************************************************
 // tests for genesis
 // *************************************************
@@ -993,101 +987,6 @@ fn do_deposit_report_existential_deposit_error() {
 		assert!(Accounts::<Runtime>::contains_key(DAVE, DOT));
 		assert_eq!(Tokens::free_balance(DOT, &DAVE), 1);
 		assert_eq!(Tokens::total_issuance(DOT), 1);
-	});
-}
-
-#[test]
-fn emit_events_when_changing_locks() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(Tokens::do_deposit(DOT, &ALICE, 100, false, false));
-		assert_ok!(Tokens::do_deposit(BTC, &ALICE, 100, false, false));
-		System::reset_events();
-
-		// Locks: [10/DOT]
-		assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 10));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
-			currency_id: DOT,
-			who: ALICE,
-			amount: 10
-		})));
-
-		// Locks: [15/DOT]
-		assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 15));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
-			currency_id: DOT,
-			who: ALICE,
-			amount: 5
-		})));
-
-		// Locks: [15/DOT, 20/BTC]
-		assert_ok!(Tokens::set_lock(ID_1, BTC, &ALICE, 20));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
-			currency_id: BTC,
-			who: ALICE,
-			amount: 20
-		})));
-
-		// Locks: [15/DOT, 20/BTC, 10/DOT]
-		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 10));
-		for event in events() {
-			match event {
-				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
-				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
-				_ => continue,
-			}
-		}
-
-		// Locks: [15/DOT, 20/BTC, 12/DOT]
-		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 12));
-		for event in events() {
-			match event {
-				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
-				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
-				_ => continue,
-			}
-		}
-
-		// Locks: [15/DOT, 20/BTC, 10/DOT]
-		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 10));
-		for event in events() {
-			match event {
-				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
-				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
-				_ => continue,
-			}
-		}
-
-		// Locks: [15/DOT, 20/BTC, 20/DOT]
-		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 20));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
-			currency_id: DOT,
-			who: ALICE,
-			amount: 5
-		})));
-
-		// Locks: [15/DOT, 20/BTC, 16/DOT]
-		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 16));
-		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
-			currency_id: DOT,
-			who: ALICE,
-			amount: 4
-		})));
-
-		// Locks: [15/DOT, 12/BTC, 16/DOT]
-		assert_ok!(Tokens::set_lock(ID_1, BTC, &ALICE, 12));
-		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
-			currency_id: BTC,
-			who: ALICE,
-			amount: 8
-		})));
-
-		// Locks: [15/DOT, 12/BTC]
-		assert_ok!(Tokens::remove_lock(ID_2, DOT, &ALICE));
-		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
-			currency_id: DOT,
-			who: ALICE,
-			amount: 1
-		})));
 	});
 }
 

--- a/tokens/src/tests_events.rs
+++ b/tokens/src/tests_events.rs
@@ -6,6 +6,12 @@ use super::*;
 use frame_support::assert_ok;
 use mock::*;
 
+fn events() -> Vec<Event> {
+	let evt = System::events().into_iter().map(|evt| evt.event).collect::<Vec<_>>();
+	System::reset_events();
+	evt
+}
+
 #[test]
 fn pallet_multicurrency_deposit_events() {
 	ExtBuilder::default()
@@ -299,4 +305,99 @@ fn currency_adapter_pallet_currency_deposit_events() {
 				reserved: 40,
 			}));
 		});
+}
+
+#[test]
+fn pallet_change_locks_events() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(Tokens::do_deposit(DOT, &ALICE, 100, false, false));
+		assert_ok!(Tokens::do_deposit(BTC, &ALICE, 100, false, false));
+		System::reset_events();
+
+		// Locks: [10/DOT]
+		assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 10));
+		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+			currency_id: DOT,
+			who: ALICE,
+			amount: 10
+		})));
+
+		// Locks: [15/DOT]
+		assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 15));
+		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+			currency_id: DOT,
+			who: ALICE,
+			amount: 5
+		})));
+
+		// Locks: [15/DOT, 20/BTC]
+		assert_ok!(Tokens::set_lock(ID_1, BTC, &ALICE, 20));
+		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+			currency_id: BTC,
+			who: ALICE,
+			amount: 20
+		})));
+
+		// Locks: [15/DOT, 20/BTC, 10/DOT]
+		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 10));
+		for event in events() {
+			match event {
+				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
+				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
+				_ => continue,
+			}
+		}
+
+		// Locks: [15/DOT, 20/BTC, 12/DOT]
+		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 12));
+		for event in events() {
+			match event {
+				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
+				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
+				_ => continue,
+			}
+		}
+
+		// Locks: [15/DOT, 20/BTC, 10/DOT]
+		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 10));
+		for event in events() {
+			match event {
+				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
+				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
+				_ => continue,
+			}
+		}
+
+		// Locks: [15/DOT, 20/BTC, 20/DOT]
+		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 20));
+		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+			currency_id: DOT,
+			who: ALICE,
+			amount: 5
+		})));
+
+		// Locks: [15/DOT, 20/BTC, 16/DOT]
+		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 16));
+		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
+			currency_id: DOT,
+			who: ALICE,
+			amount: 4
+		})));
+
+		// Locks: [15/DOT, 12/BTC, 16/DOT]
+		assert_ok!(Tokens::set_lock(ID_1, BTC, &ALICE, 12));
+		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
+			currency_id: BTC,
+			who: ALICE,
+			amount: 8
+		})));
+
+		// Locks: [15/DOT, 12/BTC]
+		assert_ok!(Tokens::remove_lock(ID_2, DOT, &ALICE));
+		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
+			currency_id: DOT,
+			who: ALICE,
+			amount: 1
+		})));
+	});
 }

--- a/tokens/src/tests_events.rs
+++ b/tokens/src/tests_events.rs
@@ -6,7 +6,7 @@ use super::*;
 use frame_support::assert_ok;
 use mock::*;
 
-fn events() -> Vec<Event> {
+fn events() -> Vec<RuntimeEvent> {
 	let evt = System::events().into_iter().map(|evt| evt.event).collect::<Vec<_>>();
 	System::reset_events();
 	evt
@@ -316,7 +316,7 @@ fn pallet_change_locks_events() {
 
 		// Locks: [10/DOT]
 		assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 10));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+		assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::Locked {
 			currency_id: DOT,
 			who: ALICE,
 			amount: 10
@@ -324,7 +324,7 @@ fn pallet_change_locks_events() {
 
 		// Locks: [15/DOT]
 		assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 15));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+		assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::Locked {
 			currency_id: DOT,
 			who: ALICE,
 			amount: 5
@@ -332,7 +332,7 @@ fn pallet_change_locks_events() {
 
 		// Locks: [15/DOT, 20/BTC]
 		assert_ok!(Tokens::set_lock(ID_1, BTC, &ALICE, 20));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+		assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::Locked {
 			currency_id: BTC,
 			who: ALICE,
 			amount: 20
@@ -342,8 +342,8 @@ fn pallet_change_locks_events() {
 		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 10));
 		for event in events() {
 			match event {
-				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
-				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
+				RuntimeEvent::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
+				RuntimeEvent::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
 				_ => continue,
 			}
 		}
@@ -352,8 +352,8 @@ fn pallet_change_locks_events() {
 		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 12));
 		for event in events() {
 			match event {
-				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
-				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
+				RuntimeEvent::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
+				RuntimeEvent::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
 				_ => continue,
 			}
 		}
@@ -362,15 +362,15 @@ fn pallet_change_locks_events() {
 		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 10));
 		for event in events() {
 			match event {
-				Event::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
-				Event::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
+				RuntimeEvent::Tokens(crate::Event::Locked { .. }) => assert!(false, "unexpected lock event"),
+				RuntimeEvent::Tokens(crate::Event::Unlocked { .. }) => assert!(false, "unexpected unlock event"),
 				_ => continue,
 			}
 		}
 
 		// Locks: [15/DOT, 20/BTC, 20/DOT]
 		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 20));
-		assert!(events().contains(&Event::Tokens(crate::Event::Locked {
+		assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::Locked {
 			currency_id: DOT,
 			who: ALICE,
 			amount: 5
@@ -378,7 +378,7 @@ fn pallet_change_locks_events() {
 
 		// Locks: [15/DOT, 20/BTC, 16/DOT]
 		assert_ok!(Tokens::set_lock(ID_2, DOT, &ALICE, 16));
-		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
+		assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::Unlocked {
 			currency_id: DOT,
 			who: ALICE,
 			amount: 4
@@ -386,7 +386,7 @@ fn pallet_change_locks_events() {
 
 		// Locks: [15/DOT, 12/BTC, 16/DOT]
 		assert_ok!(Tokens::set_lock(ID_1, BTC, &ALICE, 12));
-		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
+		assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::Unlocked {
 			currency_id: BTC,
 			who: ALICE,
 			amount: 8
@@ -394,7 +394,7 @@ fn pallet_change_locks_events() {
 
 		// Locks: [15/DOT, 12/BTC]
 		assert_ok!(Tokens::remove_lock(ID_2, DOT, &ALICE));
-		assert!(events().contains(&Event::Tokens(crate::Event::Unlocked {
+		assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::Unlocked {
 			currency_id: DOT,
 			who: ALICE,
 			amount: 1


### PR DESCRIPTION
Fundamental issue: Block indexers and processors like Subsquid have a really hard time to track locks.

This PR mirrors updates within `pallet-balances`: https://github.com/paritytech/substrate/pull/12287

Difference in respect to https://github.com/paritytech/substrate/pull/12287:
- A `currency_id` field was added to the events
- The lock `reason` was removed from the events (no differentiation between `MISC` and `FEE` reasons)

The tests cases were adjusted to the previously mentioned differences:
```rust
Locks = []                          --> [10/DOT]                    // emits Locked(currency_id: DOT, ..., amount=10)
Locks = [10/DOT]                    --> [15/DOT]                    // emits Locked(currency_id: DOT, ..., amount=5)
Locks = [15/DOT]                    --> [15/DOT, 20/BTC]            // emits Locked(currency_id: BTC, ..., amount=20)
Locks = [15/DOT, 20/BTC]            --> [15/DOT, 20/BTC, 10/DOT]    // emits nothing
Locks = [15/DOT, 20/BTC, 10/DOT]    --> [15/DOT, 20/BTC, 12/DOT]    // emits nothing
Locks = [15/DOT, 20/BTC, 12/DOT]    --> [15/DOT, 20/BTC, 10/DOT]    // emits nothing
Locks = [15/DOT, 20/BTC, 10/DOT]    --> [15/DOT, 20/BTC, 20/DOT]    // emits Locked(currency_id: DOT, ..., amount=5)
Locks = [15/DOT, 20/BTC, 20/DOT]    --> [15/DOT, 20/BTC, 16/DOT]    // emits Unlocked(currency_id: DOT, ..., amount = 4)
Locks = [15/DOT, 20/BTC, 16/DOT]    --> [15/DOT, 12/BTC, 16/DOT]    // emits Unlocked(currency_id: BTC, ..., amount = 8)
Locks = [15/DOT, 12/BTC, 16/DOT]    --> [15/DOT, 12/BTC]            // emits Unlocked(currency_id: DOT, ..., amount = 1)
```

Bonus change: Replace deprecated clippy rule name.