### PR TITLE
Implement necessary Balanced types

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1859,6 +1859,11 @@ impl<T: Config> fungibles::Mutate<T::AccountId> for Pallet<T> {
 	}
 }
 
+// impl<T: Config> fungibles::Balanced<T::AccountId> for Pallet<T> {
+// 	type OnDropDebt = IncreaseIssuance<T::AccountId, U>;
+// 	type OnDropCredit = DecreaseIssuance<T::AccountId, U>;
+// }
+
 impl<T: Config> fungibles::Unbalanced<T::AccountId> for Pallet<T> {
 	fn handle_dust(_dust: fungibles::Dust<T::AccountId, Self>) {
 		// Dust is handled in account mutate method

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -358,16 +358,6 @@ pub mod module {
 			who: T::AccountId,
 			amount: T::Balance,
 		},
-		Deposit {
-			asset: T::CurrencyId,
-			who: T::AccountId,
-			amount: T::Balance,
-		},
-		Withdraw {
-			asset: T::CurrencyId,
-			who: T::AccountId,
-			amount: T::Balance,
-		},
 		Issued {
 			asset: T::CurrencyId,
 			amount: T::Balance,
@@ -1951,15 +1941,15 @@ impl<T: Config> fungibles::Balanced<T::AccountId> for Pallet<T> {
 	type OnDropCredit = fungibles::DecreaseIssuance<T::AccountId, Self>;
 
 	fn done_deposit(asset: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
-		Self::deposit_event(Event::Deposit {
-			asset,
+		Self::deposit_event(Event::Deposited {
+			currency_id: asset,
 			who: who.clone(),
 			amount,
 		});
 	}
 	fn done_withdraw(asset: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
-		Self::deposit_event(Event::Withdraw {
-			asset,
+		Self::deposit_event(Event::Withdrawn {
+			currency_id: asset,
 			who: who.clone(),
 			amount,
 		});

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -358,6 +358,24 @@ pub mod module {
 			who: T::AccountId,
 			amount: T::Balance,
 		},
+		Deposit {
+			asset: T::CurrencyId,
+			who: T::AccountId,
+			amount: T::Balance,
+		},
+		Withdraw {
+			asset: T::CurrencyId,
+			who: T::AccountId,
+			amount: T::Balance,
+		},
+		Issued {
+			asset: T::CurrencyId,
+			amount: T::Balance,
+		},
+		Rescinded {
+			asset: T::CurrencyId,
+			amount: T::Balance,
+		},
 	}
 
 	/// The total issuance of a token type.
@@ -1929,8 +1947,29 @@ impl<T: Config> fungibles::Unbalanced<T::AccountId> for Pallet<T> {
 }
 
 impl<T: Config> fungibles::Balanced<T::AccountId> for Pallet<T> {
-	type OnDropDebt = fungibles::IncreaseIssuance<T::AccountId, Pallet<T>>;
-	type OnDropCredit = fungibles::DecreaseIssuance<T::AccountId, Pallet<T>>;
+	type OnDropDebt = fungibles::IncreaseIssuance<T::AccountId, Self>;
+	type OnDropCredit = fungibles::DecreaseIssuance<T::AccountId, Self>;
+
+	fn done_deposit(asset: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
+		Self::deposit_event(Event::Deposit {
+			asset,
+			who: who.clone(),
+			amount,
+		});
+	}
+	fn done_withdraw(asset: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
+		Self::deposit_event(Event::Withdraw {
+			asset,
+			who: who.clone(),
+			amount,
+		});
+	}
+	fn done_issue(asset: Self::AssetId, amount: Self::Balance) {
+		Self::deposit_event(Event::Issued { asset, amount });
+	}
+	fn done_rescind(asset: Self::AssetId, amount: Self::Balance) {
+		Self::deposit_event(Event::Rescinded { asset, amount });
+	}
 }
 
 type ReasonOf<P, T> = <P as fungibles::InspectHold<<T as frame_system::Config>::AccountId>>::Reason;

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -359,11 +359,11 @@ pub mod module {
 			amount: T::Balance,
 		},
 		Issued {
-			asset: T::CurrencyId,
+			currency_id: T::CurrencyId,
 			amount: T::Balance,
 		},
 		Rescinded {
-			asset: T::CurrencyId,
+			currency_id: T::CurrencyId,
 			amount: T::Balance,
 		},
 	}
@@ -1940,25 +1940,25 @@ impl<T: Config> fungibles::Balanced<T::AccountId> for Pallet<T> {
 	type OnDropDebt = fungibles::IncreaseIssuance<T::AccountId, Self>;
 	type OnDropCredit = fungibles::DecreaseIssuance<T::AccountId, Self>;
 
-	fn done_deposit(asset: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
+	fn done_deposit(currency_id: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
 		Self::deposit_event(Event::Deposited {
-			currency_id: asset,
+			currency_id,
 			who: who.clone(),
 			amount,
 		});
 	}
-	fn done_withdraw(asset: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
+	fn done_withdraw(currency_id: Self::AssetId, who: &T::AccountId, amount: Self::Balance) {
 		Self::deposit_event(Event::Withdrawn {
-			currency_id: asset,
+			currency_id,
 			who: who.clone(),
 			amount,
 		});
 	}
-	fn done_issue(asset: Self::AssetId, amount: Self::Balance) {
-		Self::deposit_event(Event::Issued { asset, amount });
+	fn done_issue(currency_id: Self::AssetId, amount: Self::Balance) {
+		Self::deposit_event(Event::Issued { currency_id, amount });
 	}
-	fn done_rescind(asset: Self::AssetId, amount: Self::Balance) {
-		Self::deposit_event(Event::Rescinded { asset, amount });
+	fn done_rescind(currency_id: Self::AssetId, amount: Self::Balance) {
+		Self::deposit_event(Event::Rescinded { currency_id, amount });
 	}
 }
 

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1859,11 +1859,6 @@ impl<T: Config> fungibles::Mutate<T::AccountId> for Pallet<T> {
 	}
 }
 
-// impl<T: Config> fungibles::Balanced<T::AccountId> for Pallet<T> {
-// 	type OnDropDebt = IncreaseIssuance<T::AccountId, U>;
-// 	type OnDropCredit = DecreaseIssuance<T::AccountId, U>;
-// }
-
 impl<T: Config> fungibles::Unbalanced<T::AccountId> for Pallet<T> {
 	fn handle_dust(_dust: fungibles::Dust<T::AccountId, Self>) {
 		// Dust is handled in account mutate method
@@ -1931,6 +1926,11 @@ impl<T: Config> fungibles::Unbalanced<T::AccountId> for Pallet<T> {
 		// here just return decrease amount, shouldn't count the dust_amount
 		Ok(old_balance.saturating_sub(new_balance))
 	}
+}
+
+impl<T: Config> fungibles::Balanced<T::AccountId> for Pallet<T> {
+	type OnDropDebt = fungibles::IncreaseIssuance<T::AccountId, Pallet<T>>;
+	type OnDropCredit = fungibles::DecreaseIssuance<T::AccountId, Pallet<T>>;
 }
 
 type ReasonOf<P, T> = <P as fungibles::InspectHold<<T as frame_system::Config>::AccountId>>::Reason;

--- a/tokens/src/tests_fungibles.rs
+++ b/tokens/src/tests_fungibles.rs
@@ -288,58 +288,92 @@ fn fungibles_unbalanced_trait_should_work() {
 }
 
 #[test]
-fn fungibles_balanced_done_deposit_emits_event() {
+fn fungibles_balanced_deposit_works() {
 	ExtBuilder::default()
 		.balances(vec![(ALICE, DOT, 100)])
 		.build()
 		.execute_with(|| {
-			<Tokens as fungibles::Balanced<_>>::done_deposit(DOT, &ALICE, 10);
+			let amount = 42;
+			let alice_old_balance = <Tokens as fungibles::Inspect<_>>::balance(DOT, &ALICE);
+			let debt = <Tokens as fungibles::Balanced<_>>::deposit(DOT, &ALICE, amount, Precision::Exact).unwrap();
+			assert_eq!(debt.asset(), DOT);
+			assert_eq!(debt.peek(), amount);
+			let alice_new_balance = <Tokens as fungibles::Inspect<_>>::balance(DOT, &ALICE);
+			assert_eq!(alice_old_balance + amount, alice_new_balance);
 
-			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Deposit {
-				asset: DOT,
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Deposited {
+				currency_id: DOT,
 				who: ALICE,
-				amount: 10,
+				amount,
 			}));
 		});
 }
 
 #[test]
-fn fungibles_balanced_done_withdraw_emits_event() {
+fn fungibles_balanced_withdraw_works() {
 	ExtBuilder::default()
 		.balances(vec![(ALICE, DOT, 100)])
 		.build()
 		.execute_with(|| {
-			<Tokens as fungibles::Balanced<_>>::done_withdraw(DOT, &ALICE, 10);
+			let amount = 42;
+			let alice_old_balance = <Tokens as fungibles::Inspect<_>>::balance(DOT, &ALICE);
+			let credit = <Tokens as fungibles::Balanced<_>>::withdraw(
+				DOT,
+				&ALICE,
+				amount,
+				Precision::Exact,
+				Preservation::Protect,
+				Fortitude::Polite,
+			)
+			.unwrap();
+			assert_eq!(credit.asset(), DOT);
+			assert_eq!(credit.peek(), amount);
+			let alice_new_balance = <Tokens as fungibles::Inspect<_>>::balance(DOT, &ALICE);
+			assert_eq!(alice_old_balance - amount, alice_new_balance);
 
-			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Withdraw {
-				asset: DOT,
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Withdrawn {
+				currency_id: DOT,
 				who: ALICE,
-				amount: 10,
+				amount,
 			}));
 		});
 }
 
 #[test]
-fn fungibles_balanced_done_issue_emits_event() {
+fn fungibles_balanced_issue_works() {
 	ExtBuilder::default()
 		.balances(vec![(ALICE, DOT, 100)])
 		.build()
 		.execute_with(|| {
-			<Tokens as fungibles::Balanced<_>>::done_issue(DOT, 10);
+			let amount = 42;
 
-			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Issued { asset: DOT, amount: 10 }));
+			let old_total_issuance = <Tokens as fungibles::Inspect<_>>::total_issuance(DOT);
+			let credit = <Tokens as fungibles::Balanced<_>>::issue(DOT, amount);
+			assert_eq!(credit.asset(), DOT);
+			assert_eq!(credit.peek(), amount);
+			let new_total_issuance = <Tokens as fungibles::Inspect<_>>::total_issuance(DOT);
+			assert_eq!(old_total_issuance + amount, new_total_issuance);
+
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Issued { asset: DOT, amount }));
 		});
 }
 
 #[test]
-fn fungibles_balanced_done_rescind_emits_event() {
+fn fungibles_balanced_rescind_works() {
 	ExtBuilder::default()
 		.balances(vec![(ALICE, DOT, 100)])
 		.build()
 		.execute_with(|| {
-			<Tokens as fungibles::Balanced<_>>::done_rescind(DOT, 10);
+			let amount = 42;
 
-			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Rescinded { asset: DOT, amount: 10 }));
+			let old_total_issuance = <Tokens as fungibles::Inspect<_>>::total_issuance(DOT);
+			let debt = <Tokens as fungibles::Balanced<_>>::rescind(DOT, amount);
+			assert_eq!(debt.asset(), DOT);
+			assert_eq!(debt.peek(), amount);
+			let new_total_issuance = <Tokens as fungibles::Inspect<_>>::total_issuance(DOT);
+			assert_eq!(old_total_issuance - amount, new_total_issuance);
+
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Rescinded { asset: DOT, amount }));
 		});
 }
 

--- a/tokens/src/tests_fungibles.rs
+++ b/tokens/src/tests_fungibles.rs
@@ -354,7 +354,10 @@ fn fungibles_balanced_issue_works() {
 			let new_total_issuance = <Tokens as fungibles::Inspect<_>>::total_issuance(DOT);
 			assert_eq!(old_total_issuance + amount, new_total_issuance);
 
-			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Issued { asset: DOT, amount }));
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Issued {
+				currency_id: DOT,
+				amount,
+			}));
 		});
 }
 
@@ -373,7 +376,10 @@ fn fungibles_balanced_rescind_works() {
 			let new_total_issuance = <Tokens as fungibles::Inspect<_>>::total_issuance(DOT);
 			assert_eq!(old_total_issuance - amount, new_total_issuance);
 
-			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Rescinded { asset: DOT, amount }));
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Rescinded {
+				currency_id: DOT,
+				amount,
+			}));
 		});
 }
 

--- a/tokens/src/tests_fungibles.rs
+++ b/tokens/src/tests_fungibles.rs
@@ -288,6 +288,62 @@ fn fungibles_unbalanced_trait_should_work() {
 }
 
 #[test]
+fn fungibles_balanced_done_deposit_emits_event() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, DOT, 100)])
+		.build()
+		.execute_with(|| {
+			<Tokens as fungibles::Balanced<_>>::done_deposit(DOT, &ALICE, 10);
+
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Deposit {
+				asset: DOT,
+				who: ALICE,
+				amount: 10,
+			}));
+		});
+}
+
+#[test]
+fn fungibles_balanced_done_withdraw_emits_event() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, DOT, 100)])
+		.build()
+		.execute_with(|| {
+			<Tokens as fungibles::Balanced<_>>::done_withdraw(DOT, &ALICE, 10);
+
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Withdraw {
+				asset: DOT,
+				who: ALICE,
+				amount: 10,
+			}));
+		});
+}
+
+#[test]
+fn fungibles_balanced_done_issue_emits_event() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, DOT, 100)])
+		.build()
+		.execute_with(|| {
+			<Tokens as fungibles::Balanced<_>>::done_issue(DOT, 10);
+
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Issued { asset: DOT, amount: 10 }));
+		});
+}
+
+#[test]
+fn fungibles_balanced_done_rescind_emits_event() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, DOT, 100)])
+		.build()
+		.execute_with(|| {
+			<Tokens as fungibles::Balanced<_>>::done_rescind(DOT, 10);
+
+			System::assert_last_event(RuntimeEvent::Tokens(crate::Event::Rescinded { asset: DOT, amount: 10 }));
+		});
+}
+
+#[test]
 fn fungibles_inspect_hold_trait_should_work() {
 	ExtBuilder::default()
 		.balances(vec![(ALICE, DOT, 100)])


### PR DESCRIPTION
Fixes https://github.com/open-web3-stack/open-runtime-module-library/issues/930

This implements the `fungibles::Balanced` traits associated types. 

My reference is originally from [here](https://github.com/paritytech/substrate/blob/cb4f2491b00af7d7817f3a54209c26b20faa1f51/frame/support/src/traits/tokens/fungible/balanced.rs#L313-L354) (an older default implementation for the Balanced trait inside of substrate).