### PR TITLE
emit LockSet on extend_lock

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1329,9 +1329,18 @@ impl<T: Config> MultiLockableCurrency<T::AccountId> for Pallet<T> {
 			.into_iter()
 			.filter_map(|lock| {
 				if lock.id == lock_id {
-					new_lock.take().map(|nl| BalanceLock {
-						id: lock.id,
-						amount: lock.amount.max(nl.amount),
+					new_lock.take().map(|nl| {
+						let new_amount = lock.amount.max(nl.amount);
+						Self::deposit_event(Event::LockSet {
+							lock_id,
+							currency_id,
+							who: who.clone(),
+							amount: new_amount,
+						});
+						BalanceLock {
+							id: lock.id,
+							amount: new_amount,
+						}
 					})
 				} else {
 					Some(lock)

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1339,6 +1339,12 @@ impl<T: Config> MultiLockableCurrency<T::AccountId> for Pallet<T> {
 			})
 			.collect::<Vec<_>>();
 		if let Some(lock) = new_lock {
+			Self::deposit_event(Event::LockSet {
+				lock_id,
+				currency_id,
+				who: who.clone(),
+				amount: lock.amount,
+			});
 			locks.push(lock)
 		}
 		Self::update_locks(currency_id, who, &locks[..])

--- a/tokens/src/tests_events.rs
+++ b/tokens/src/tests_events.rs
@@ -422,3 +422,36 @@ fn pallet_change_locks_events() {
 		})));
 	});
 }
+
+#[test]
+fn pallet_multi_lockable_currency_extend_lock_events() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, DOT, 100)])
+		.build()
+		.execute_with(|| {
+			// lock already exists
+			assert_ok!(Tokens::set_lock(ID_1, DOT, &ALICE, 10));
+			assert_ok!(Tokens::extend_lock(ID_1, DOT, &ALICE, 20));
+			assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::LockSet {
+				lock_id: ID_1,
+				currency_id: DOT,
+				who: ALICE,
+				amount: 20,
+			})));
+			// lock doesn't exist
+			assert_ok!(Tokens::extend_lock(ID_2, DOT, &ALICE, 10));
+			assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::LockSet {
+				lock_id: ID_2,
+				currency_id: DOT,
+				who: ALICE,
+				amount: 10,
+			})));
+			assert_ok!(Tokens::extend_lock(ID_2, DOT, &ALICE, 20));
+			assert!(events().contains(&RuntimeEvent::Tokens(crate::Event::LockSet {
+				lock_id: ID_2,
+				currency_id: DOT,
+				who: ALICE,
+				amount: 20,
+			})));
+		});
+}


### PR DESCRIPTION
Adds the `LockSet` event if an existing lock is extended so processors like Squid can still correctly track the locked balance.