### PR TITLE
Fix MessageQueue pallet order in mocks

### DIFF
--- a/asset-registry/src/mock/relay.rs
+++ b/asset-registry/src/mock/relay.rs
@@ -222,7 +222,7 @@ construct_runtime!(
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		ParasOrigin: origin::{Pallet, Origin},
-		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin},
 		MessageQueue: pallet_message_queue::{Pallet, Event<T>},
+		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin},
 	}
 );

--- a/xtokens/src/mock/relay.rs
+++ b/xtokens/src/mock/relay.rs
@@ -228,7 +228,7 @@ construct_runtime!(
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		ParasOrigin: origin::{Pallet, Origin},
-		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin},
 		MessageQueue: pallet_message_queue::{Pallet, Event<T>},
+		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin},
 	}
 );


### PR DESCRIPTION
This change will prevent getting some encoding errors with XCM related tests in the future.

Edit: To give more context, the reason why this change is needed is because the new `MessageQueue` pallet should be placed at the same index where the old `ParasUmp` pallet was situated before it was removed in the upgrade to v0.9.43. 

If we test the execution of an upward message with the current mock configuration, in most of the cases it will pass without any problem, but in some other ones it will fail while processing the XCM Transact instruction, more specifically while decoding the call that this instruction receives. This was the case in Moonbeam for instance, where we encountered that some XCM tests were failing due to this while testing the upgrade to v0.9.43. These issues got solved by placing the new `MessageQueue` pallet in the correct index.