### PR TITLE
add erc20 compatible allowances

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -137,7 +137,7 @@ pub struct ReserveData<ReserveIdentifier, Balance> {
 	pub amount: Balance,
 }
 
-/// balance information for an account.
+/// Balance information for an account.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, MaxEncodedLen, RuntimeDebug, TypeInfo)]
 pub struct AccountData<Balance> {
 	/// Non-reserved part of the balance. There may still be restrictions on
@@ -256,6 +256,8 @@ pub mod module {
 		DeadAccount,
 		// Number of named reserves exceed `T::MaxReserves`
 		TooManyReserves,
+		/// The allowance is too low
+		AllowanceTooLow,
 	}
 
 	#[pallet::event]
@@ -366,6 +368,13 @@ pub mod module {
 			currency_id: T::CurrencyId,
 			amount: T::Balance,
 		},
+		/// Some allowance was updated
+		AllowanceSet {
+			currency_id: T::CurrencyId,
+			owner: T::AccountId,
+			spender: T::AccountId,
+			amount: T::Balance,
+		},
 	}
 
 	/// The total issuance of a token type.
@@ -415,6 +424,19 @@ pub mod module {
 		Twox64Concat,
 		T::CurrencyId,
 		BoundedVec<ReserveData<T::ReserveIdentifier, T::Balance>, T::MaxReserves>,
+		ValueQuery,
+	>;
+
+	/// Allowances for accounts to spend approved funds.
+	#[pallet::storage]
+	pub(super) type Allowances<T: Config> = StorageNMap<
+		_,
+		(
+			NMapKey<Blake2_128Concat, T::CurrencyId>, // currency
+			NMapKey<Blake2_128Concat, T::AccountId>,  // owner
+			NMapKey<Blake2_128Concat, T::AccountId>,  // spender
+		),
+		T::Balance, // amount
 		ValueQuery,
 	>;
 
@@ -646,6 +668,84 @@ pub mod module {
 				});
 				Ok(())
 			})?;
+
+			Ok(())
+		}
+
+		/// Approve the `spender` to spend an `amount` from the free balance of `owner`.
+		///
+		/// The dispatch origin for this call must be `Signed` by the owner.
+		///
+		/// - `spender`: The account to approve spending.
+		/// - `currency_id`: currency type.
+		/// - `amount`: free balance amount to allow.
+		#[pallet::call_index(5)]
+		#[pallet::weight(T::WeightInfo::set_allowance())]
+		pub fn set_allowance(
+			origin: OriginFor<T>,
+			spender: <T::Lookup as StaticLookup>::Source,
+			currency_id: T::CurrencyId,
+			#[pallet::compact] amount: T::Balance,
+		) -> DispatchResult {
+			let owner = ensure_signed(origin)?;
+			let spender = T::Lookup::lookup(spender)?;
+
+			Allowances::<T>::insert((&currency_id, &owner, &spender), amount);
+
+			Self::deposit_event(Event::AllowanceSet {
+				currency_id,
+				owner,
+				spender,
+				amount,
+			});
+
+			Ok(())
+		}
+
+		/// Spender can transfer some free balance from the approved account.
+		///
+		/// The dispatch origin for this call must be `Signed` by the spender.
+		///
+		/// - `from`: The account which approved spending.
+		/// - `from`: The recipient of the transfer.
+		/// - `currency_id`: currency type.
+		/// - `amount`: free balance amount to allow.
+		#[pallet::call_index(6)]
+		#[pallet::weight(T::WeightInfo::set_balance())]
+		pub fn transfer_allowance(
+			origin: OriginFor<T>,
+			from: <T::Lookup as StaticLookup>::Source,
+			to: <T::Lookup as StaticLookup>::Source,
+			currency_id: T::CurrencyId,
+			#[pallet::compact] amount: T::Balance,
+		) -> DispatchResult {
+			let spender = ensure_signed(origin)?;
+			let owner = T::Lookup::lookup(from)?;
+			let destination = T::Lookup::lookup(to)?;
+
+			let remaining = Allowances::<T>::try_mutate(
+				(&currency_id, &owner, &spender),
+				|allowance| -> Result<T::Balance, DispatchError> {
+					let remaining = allowance.checked_sub(&amount).ok_or(Error::<T>::AllowanceTooLow)?;
+					*allowance = remaining;
+					Ok(remaining)
+				},
+			)?;
+
+			Self::deposit_event(Event::AllowanceSet {
+				currency_id,
+				owner: owner.clone(),
+				spender,
+				amount: remaining,
+			});
+
+			Self::do_transfer(
+				currency_id,
+				&owner,
+				&destination,
+				amount,
+				ExistenceRequirement::KeepAlive,
+			)?;
 
 			Ok(())
 		}

--- a/tokens/src/weights.rs
+++ b/tokens/src/weights.rs
@@ -34,6 +34,8 @@ pub trait WeightInfo {
 	fn transfer_keep_alive() -> Weight;
 	fn force_transfer() -> Weight;
 	fn set_balance() -> Weight;
+	fn set_allowance() -> Weight;
+	fn transfer_allowance() -> Weight;
 }
 
 /// Default weights.
@@ -59,6 +61,16 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	fn set_balance() -> Weight {
+		Weight::from_parts(34_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+	}
+	fn set_allowance() -> Weight {
+		Weight::from_parts(34_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+	}
+	fn transfer_allowance() -> Weight {
 		Weight::from_parts(34_000_000, 0)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))


### PR DESCRIPTION
I'm not sure if this has been considered before, but we are working on adding ERC20 precompiles [here](https://github.com/interlay/interbtc/pull/1181) and we need some way to approve the spending of funds. Substrate already supports [this](https://github.com/paritytech/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/frame/assets/src/lib.rs#L347-L359) in `pallet-assets` so we can follow their design approach. For instance they do require deposits which I have currently omitted from this PR for simplicity but let me know if that is something you'd like to see. Otherwise the current change itself is trivial, we have another storage map which tracks the total amount approved for spending which can be updated either by the `set_allowance` extrinsic or it will decreased when the spender calls `transfer_allowance`.