### PR TITLE
[XNFT PoC] xtokens non-fungible multiassets support

### DIFF
--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -526,25 +526,39 @@ pub mod module {
 			let asset_len = assets.len();
 			for i in 0..asset_len {
 				let asset = assets.get(i).ok_or(Error::<T>::AssetIndexNonExistent)?;
-				ensure!(
-					matches!(asset.fun, Fungibility::Fungible(x) if !x.is_zero()),
-					Error::<T>::InvalidAsset
-				);
-				// `assets` includes fee, the reserve location is decided by non fee asset
-				if (fee != *asset && non_fee_reserve.is_none()) || asset_len == 1 {
-					non_fee_reserve = T::ReserveProvider::reserve(asset);
-				}
-				// make sure all non fee assets share the same reserve
-				if non_fee_reserve.is_some() {
+
+				if fee == *asset {
+					// Fee payment can only be made by using fungibles
 					ensure!(
-						non_fee_reserve == T::ReserveProvider::reserve(asset),
-						Error::<T>::DistinctReserveForAssetAndFee
+						matches!(asset.fun, Fungibility::Fungible(x) if !x.is_zero()),
+						Error::<T>::InvalidAsset
 					);
+				} else {
+					match asset.fun {
+						Fungibility::Fungible(x) => ensure!(!x.is_zero(), Error::<T>::InvalidAsset),
+						Fungibility::NonFungible(AssetInstance::Undefined) => {
+							return Err(Error::<T>::InvalidAsset.into())
+						}
+						_ => {}
+					}
+
+					// `assets` includes fee, the reserve location is decided by non fee asset
+					if non_fee_reserve.is_none() {
+						non_fee_reserve = T::ReserveProvider::reserve(asset);
+					}
+
+					// make sure all non fee assets share the same reserve
+					if non_fee_reserve.is_some() {
+						ensure!(
+							non_fee_reserve == T::ReserveProvider::reserve(asset),
+							Error::<T>::DistinctReserveForAssetAndFee
+						);
+					}
 				}
 			}
 
 			let fee_reserve = T::ReserveProvider::reserve(&fee);
-			if fee_reserve != non_fee_reserve {
+			if asset_len > 1 && fee_reserve != non_fee_reserve {
 				// Current only support `ToReserve` with relay-chain asset as fee. other case
 				// like `NonReserve` or `SelfReserve` with relay-chain fee is not support.
 				ensure!(non_fee_reserve == dest.chain_part(), Error::<T>::InvalidAsset);
@@ -610,7 +624,7 @@ pub mod module {
 					origin_location,
 					assets.clone(),
 					fee.clone(),
-					non_fee_reserve,
+					fee_reserve,
 					&dest,
 					None,
 					dest_weight_limit,

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -1721,3 +1721,100 @@ fn send_with_insufficient_weight_limit() {
 		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &BOB), 0);
 	});
 }
+
+#[test]
+fn send_multiasset_with_zero_fee_should_yield_an_error() {
+	TestNet::reset();
+
+	let asset_id: AssetId = X1(Junction::from(BoundedVec::try_from(b"A".to_vec()).unwrap())).into();
+	ParaA::execute_with(|| {
+		assert_noop!(
+			ParaXTokens::transfer_multiasset_with_fee(
+				Some(ALICE).into(),
+				Box::new((asset_id, 100).into()),
+				Box::new((asset_id, Fungibility::Fungible(0)).into()),
+				Box::new(
+					MultiLocation::new(
+						1,
+						X2(
+							Parachain(2),
+							Junction::AccountId32 {
+								network: None,
+								id: BOB.into()
+							},
+						)
+					)
+					.into()
+				),
+				WeightLimit::Unlimited,
+			),
+			Error::<para::Runtime>::InvalidAsset
+		);
+	});
+}
+
+#[test]
+fn send_undefined_nft_should_yield_an_error() {
+	TestNet::reset();
+
+	let fee_id: AssetId = X1(Junction::from(BoundedVec::try_from(b"A".to_vec()).unwrap())).into();
+	let nft_id: AssetId = X1(Junction::GeneralIndex(42)).into();
+
+	ParaA::execute_with(|| {
+		assert_noop!(
+			ParaXTokens::transfer_multiasset_with_fee(
+				Some(ALICE).into(),
+				Box::new((nft_id, Undefined).into()),
+				Box::new((fee_id, 100).into()),
+				Box::new(
+					MultiLocation::new(
+						1,
+						X2(
+							Parachain(2),
+							Junction::AccountId32 {
+								network: None,
+								id: BOB.into()
+							},
+						)
+					)
+					.into()
+				),
+				WeightLimit::Unlimited,
+			),
+			Error::<para::Runtime>::InvalidAsset
+		);
+	});
+}
+
+#[test]
+fn nfts_cannot_be_fee_assets() {
+	TestNet::reset();
+
+	let asset_id: AssetId = X1(Junction::from(BoundedVec::try_from(b"A".to_vec()).unwrap())).into();
+	let nft_id: AssetId = X1(Junction::GeneralIndex(42)).into();
+
+	ParaA::execute_with(|| {
+		assert_noop!(
+			ParaXTokens::transfer_multiasset_with_fee(
+				Some(ALICE).into(),
+				Box::new((asset_id, 100).into()),
+				Box::new((nft_id, Index(1)).into()),
+				Box::new(
+					MultiLocation::new(
+						1,
+						X2(
+							Parachain(2),
+							Junction::AccountId32 {
+								network: None,
+								id: BOB.into()
+							},
+						)
+					)
+					.into()
+				),
+				WeightLimit::Unlimited,
+			),
+			Error::<para::Runtime>::InvalidAsset
+		);
+	});
+}


### PR DESCRIPTION
A change to the `do_transfer_multiassets`: support of the `NonFungible` fungibility for non-fee assets.

This PR doesn't change the API of extrinsics that use the configurable `CurrencyId` since it is a PoC. In the future, we could alter the `amount` argument to take the fungibility into account.

So only the following extrinsics can be used to transfer an NFT asset:
* `transferMultiasset`
* `transferMultiassetWithFee`
* `transferMultiassets`
