### PR TITLE
fix: reducible_balance to return liquid minus ED in case of Preserve preservation

### DIFF
--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -3,7 +3,7 @@ name = "orml-tokens"
 description = "Fungible tokens module that implements `MultiCurrency` trait."
 repository = "https://github.com/open-web3-stack/open-runtime-module-library/tree/master/tokens"
 license = "Apache-2.0"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2021"
 

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1808,7 +1808,9 @@ impl<T: Config> fungibles::Inspect<T::AccountId> for Pallet<T> {
 		let a = Self::accounts(who, asset_id);
 		// Liquid balance is what is neither reserved nor locked/frozen.
 		let liquid = a.free.saturating_sub(a.frozen);
-		if frame_system::Pallet::<T>::can_dec_provider(who) && !matches!(preservation, Preservation::Protect) {
+		if frame_system::Pallet::<T>::can_dec_provider(who)
+			&& !matches!(preservation, Preservation::Protect | Preservation::Preserve)
+		{
 			liquid
 		} else {
 			// `must_remain_to_exist` is the part of liquid balance which must remain to

--- a/tokens/src/tests_fungibles.rs
+++ b/tokens/src/tests_fungibles.rs
@@ -27,6 +27,15 @@ fn fungibles_inspect_trait_should_work() {
 				),
 				98
 			);
+			assert_eq!(
+				<Tokens as fungibles::Inspect<_>>::reducible_balance(
+					DOT,
+					&ALICE,
+					Preservation::Preserve,
+					Fortitude::Polite
+				),
+				98
+			);
 			assert_ok!(
 				<Tokens as fungibles::Inspect<_>>::can_deposit(DOT, &ALICE, 1, Provenance::Extant).into_result()
 			);


### PR DESCRIPTION
See more here: https://github.com/open-web3-stack/open-runtime-module-library/issues/986

Test is added.

It is a non-breaking change.