### PR TITLE
polkadot v1.12.0

### DIFF
--- a/Cargo.dev.toml
+++ b/Cargo.dev.toml
@@ -37,35 +37,35 @@ scale-info = { version = "2.10.0", default-features = false, features = ["derive
 serde = { version = "1.0.189" }
 parity-scale-codec = { version = "3.6.5", default-features = false, features = ["max-encoded-len"] }
 
-cumulus-pallet-xcm = { version = "0.11.0", default-features = false }
-cumulus-primitives-core = { version = "0.11.0", default-features = false }
-frame-benchmarking = { version = "32.0.0", default-features = false }
-frame-support = { version = "32.0.0", default-features = false }
-frame-system = { version = "32.0.0", default-features = false }
-pallet-balances = { version = "33.0.0", default-features = false }
-pallet-elections-phragmen = { version = "33.0.0", default-features = false }
-pallet-message-queue = { version = "35.0.0", default-features = false }
-pallet-preimage = { version = "32.0.0", default-features = false }
-pallet-root-testing = { version = "8.0.0", default-features = false }
-pallet-scheduler = { version = "33.0.0", default-features = false }
-pallet-timestamp = { version = "31.0.0", default-features = false }
-pallet-treasury = { version = "31.0.0", default-features = false }
-pallet-xcm = { version = "11.0.0", default-features = false }
-polkadot-parachain-primitives = { version = "10.0.0", default-features = false }
-polkadot-runtime-common = { version = "11.0.0", default-features = false }
-polkadot-runtime-parachains = { version = "11.0.0", default-features = false }
-sp-api = { version = "30.0.0", default-features = false }
-sp-application-crypto = { version = "34.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.13.0", default-features = false }
+cumulus-primitives-core = { version = "0.13.0", default-features = false }
+frame-benchmarking = { version = "34.0.0", default-features = false }
+frame-support = { version = "34.0.0", default-features = false }
+frame-system = { version = "34.0.1", default-features = false }
+pallet-balances = { version = "35.0.0", default-features = false }
+pallet-elections-phragmen = { version = "35.0.0", default-features = false }
+pallet-message-queue = { version = "37.0.0", default-features = false }
+pallet-preimage = { version = "34.0.0", default-features = false }
+pallet-root-testing = { version = "10.0.0", default-features = false }
+pallet-scheduler = { version = "35.0.0", default-features = false }
+pallet-timestamp = { version = "33.0.0", default-features = false }
+pallet-treasury = { version = "33.0.0", default-features = false }
+pallet-xcm = { version = "13.0.0", default-features = false }
+polkadot-parachain-primitives = { version = "12.0.0", default-features = false }
+polkadot-runtime-common = { version = "13.0.0", default-features = false }
+polkadot-runtime-parachains = { version = "13.0.0", default-features = false }
+sp-api = { version = "32.0.0", default-features = false }
+sp-application-crypto = { version = "36.0.0", default-features = false }
 sp-arithmetic = { version = "26.0.0", default-features = false }
-sp-core = { version = "32.0.0", default-features = false }
-sp-io = { version = "34.0.0", default-features = false }
-sp-runtime = { version = "35.0.0", default-features = false }
+sp-core = { version = "33.0.1", default-features = false }
+sp-io = { version = "36.0.0", default-features = false }
+sp-runtime = { version = "37.0.0", default-features = false }
 sp-runtime-interface = { version = "27.0.0", default-features = false }
-sp-staking = { version = "30.0.0", default-features = false }
+sp-staking = { version = "32.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 sp-storage = { version = "21.0.0", default-features = false }
-xcm = { version = "11.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "11.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "11.0.0", package = "staging-xcm-executor", default-features = false }
+xcm = { version = "13.0.1", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "13.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "13.0.0", package = "staging-xcm-executor", default-features = false }
 
-xcm-simulator = { version = "11.0.0" }
+xcm-simulator = { version = "13.0.0" }

--- a/asset-registry/src/mock/para.rs
+++ b/asset-registry/src/mock/para.rs
@@ -236,6 +236,7 @@ impl Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = ();
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/asset-registry/src/mock/relay.rs
+++ b/asset-registry/src/mock/relay.rs
@@ -113,6 +113,7 @@ impl Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = ();
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, KusamaNetwork>;

--- a/benchmarking/Cargo.toml
+++ b/benchmarking/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true, optional = true }
 frame-benchmarking = { workspace = true }
 frame-support = { workspace = true }
 sp-api = { workspace = true }
+sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-runtime-interface = { workspace = true }
@@ -38,6 +39,7 @@ std = [
 	"scale-info/std",
 	"serde",
 	"sp-api/std",
+	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime-interface/std",
 	"sp-runtime/std",

--- a/benchmarking/src/lib.rs
+++ b/benchmarking/src/lib.rs
@@ -867,14 +867,14 @@ macro_rules! impl_benchmark {
 		#[cfg(test)]
 		impl Benchmark {
 			/// Test a particular benchmark by name.
-            ///
-            /// This isn't called `test_benchmark_by_name` just in case some end-user eventually
-            /// writes a benchmark, itself called `by_name`; the function would be shadowed in
-            /// that case.
-            ///
-            /// This is generally intended to be used by child test modules such as those created
-            /// by the `impl_benchmark_test_suite` macro. However, it is not an error if a pallet
-            /// author chooses not to implement benchmarks.
+			///
+			/// This isn't called `test_benchmark_by_name` just in case some end-user eventually
+			/// writes a benchmark, itself called `by_name`; the function would be shadowed in
+			/// that case.
+			///
+			/// This is generally intended to be used by child test modules such as those created
+			/// by the `impl_benchmark_test_suite` macro. However, it is not an error if a pallet
+			/// author chooses not to implement benchmarks.
 			#[allow(unused)]
 			fn test_bench_by_name(name: &[u8]) -> Result<(), $crate::BenchmarkError> {
 				let name = $crate::str::from_utf8(name)
@@ -1153,7 +1153,7 @@ macro_rules! impl_benchmark_test_suite {
 									err,
 								);
 								anything_failed = true;
-							}
+							},
 							Ok(Err(err)) => {
 								match err {
 									$crate::BenchmarkError::Stop(err) => {
@@ -1164,7 +1164,7 @@ macro_rules! impl_benchmark_test_suite {
 											err,
 										);
 										anything_failed = true;
-									}
+									},
 									$crate::BenchmarkError::Override(_) => {
 										// This is still considered a success condition.
 										$crate::log::error!(
@@ -1172,7 +1172,7 @@ macro_rules! impl_benchmark_test_suite {
 											$crate::str::from_utf8(benchmark_name)
 												.expect("benchmark name is always a valid string!"),
 										);
-									}
+									},
 									$crate::BenchmarkError::Skip => {
 										// This is considered a success condition.
 										$crate::log::error!(
@@ -1180,7 +1180,7 @@ macro_rules! impl_benchmark_test_suite {
 											$crate::str::from_utf8(benchmark_name)
 												.expect("benchmark name is always a valid string!"),
 										);
-									}
+									},
 									$crate::BenchmarkError::Weightless => {
 										// This is considered a success condition.
 										$crate::log::error!(
@@ -1190,7 +1190,7 @@ macro_rules! impl_benchmark_test_suite {
 										);
 									}
 								}
-							}
+							},
 							Ok(Ok(())) => (),
 						}
 					}
@@ -1304,7 +1304,7 @@ macro_rules! add_benchmark {
 						(b"Benchmark Override".to_vec(), 0, 0, false)
 					);
 					Some($crate::vec![result])
-				}
+				},
 				Err($crate::BenchmarkError::Stop(e)) => {
 					$crate::show_benchmark_debug_info(
 						instance_string,
@@ -1314,7 +1314,7 @@ macro_rules! add_benchmark {
 						e,
 					);
 					return Err(e.into());
-				}
+				},
 				Err($crate::BenchmarkError::Skip) => {
 					$crate::log::error!(
 						"WARNING: benchmark error skipped - {}",
@@ -1322,7 +1322,7 @@ macro_rules! add_benchmark {
 							.expect("benchmark name is always a valid string!")
 					);
 					None
-				}
+				},
 				Err($crate::BenchmarkError::Weightless) => {
 					$crate::log::error!(
 						"WARNING: benchmark weightless skipped - {}",
@@ -1417,12 +1417,12 @@ macro_rules! cb_list_benchmarks {
 macro_rules! define_benchmarks {
     ( $([ $names:path, $( $locations:tt )* ])* ) => {
 		/// Calls `list_benchmark` with all configs from `define_benchmarks`
-        /// and passes the first two parameters on.
-        ///
-        /// Use as:
-        /// ```ignore
-        /// list_benchmarks!(list, extra);
-        /// ```
+		/// and passes the first two parameters on.
+		///
+		/// Use as:
+		/// ```ignore
+		/// list_benchmarks!(list, extra);
+		/// ```
 		#[macro_export]
 		macro_rules! list_benchmarks {
             ( $list:ident, $extra:ident ) => {
@@ -1431,12 +1431,12 @@ macro_rules! define_benchmarks {
         }
 
 		/// Calls `add_benchmark` with all configs from `define_benchmarks`
-        /// and passes the first two parameters on.
-        ///
-        /// Use as:
-        /// ```ignore
-        /// add_benchmarks!(params, batches);
-        /// ```
+		/// and passes the first two parameters on.
+		///
+		/// Use as:
+		/// ```ignore
+		/// add_benchmarks!(params, batches);
+		/// ```
 		#[macro_export]
 		macro_rules! add_benchmarks {
             ( $params:ident, $batches:ident ) => {

--- a/benchmarking/src/lib.rs
+++ b/benchmarking/src/lib.rs
@@ -923,7 +923,7 @@ macro_rules! impl_benchmark_test {
 						};
 
 						// Run execution + verification
-						<SelectedBenchmark as $crate::BenchmarkingSetup<$runtime, _>>::test_instance(&selected_benchmark, &c, &on_before_start);
+						<SelectedBenchmark as $crate::BenchmarkingSetup<$runtime, _>>::test_instance(&selected_benchmark, &c, &on_before_start)?;
 
 						// Reset the state
 						$crate::benchmarking::wipe_db();

--- a/benchmarking/src/tests.rs
+++ b/benchmarking/src/tests.rs
@@ -127,79 +127,67 @@ fn benchmarks_macro_works() {
 	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected_benchmark);
 	assert_eq!(components, vec![(BenchmarkParameter::b, 1, 1000)]);
 
-	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
-		&selected_benchmark,
-		&[(BenchmarkParameter::b, 1)],
-		true,
-	)
-	.expect("failed to create closure");
-
 	new_test_ext().execute_with(|| {
-		assert_eq!(closure(), Ok(()));
+		assert_ok!(<SelectedBenchmark as BenchmarkingSetup<Test>>::unit_test_instance(
+			&selected_benchmark,
+			&[(BenchmarkParameter::b, 1)],
+		));
 	});
 }
 
 #[test]
 fn benchmarks_macro_rename_works() {
 	// Check benchmark creation for `other_dummy`.
-	let selected_benchmark = SelectedBenchmark::other_name;
-	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected_benchmark);
+	let selected = SelectedBenchmark::other_name;
+	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected);
 	assert_eq!(components, vec![(BenchmarkParameter::b, 1, 1000)]);
 
-	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
-		&selected_benchmark,
-		&[(BenchmarkParameter::b, 1)],
-		true,
-	)
-	.expect("failed to create closure");
-
 	new_test_ext().execute_with(|| {
-		assert_ok!(closure());
+		assert_ok!(<SelectedBenchmark as BenchmarkingSetup<Test>>::unit_test_instance(
+			&selected,
+			&[(BenchmarkParameter::b, 1)],
+		));
 	});
 }
 
 #[test]
 fn benchmarks_macro_works_for_non_dispatchable() {
-	let selected_benchmark = SelectedBenchmark::sort_vector;
+	let selected = SelectedBenchmark::sort_vector;
 
-	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected_benchmark);
+	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected);
 	assert_eq!(components, vec![(BenchmarkParameter::x, 1, 10000)]);
 
-	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
-		&selected_benchmark,
-		&[(BenchmarkParameter::x, 1)],
-		true,
-	)
-	.expect("failed to create closure");
-
-	assert_eq!(closure(), Ok(()));
+	new_test_ext().execute_with(|| {
+		assert_ok!(<SelectedBenchmark as BenchmarkingSetup<Test>>::unit_test_instance(
+			&selected,
+			&[(BenchmarkParameter::x, 1)],
+		));
+	});
 }
 
 #[test]
 fn benchmarks_macro_verify_works() {
 	// Check postcondition for benchmark `set_value` is valid.
-	let selected_benchmark = SelectedBenchmark::set_value;
-
-	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
-		&selected_benchmark,
-		&[(BenchmarkParameter::b, 1)],
-		true,
-	)
-	.expect("failed to create closure");
+	let selected = SelectedBenchmark::set_value;
 
 	new_test_ext().execute_with(|| {
-		assert_ok!(closure());
+		assert_ok!(<SelectedBenchmark as BenchmarkingSetup<Test>>::unit_test_instance(
+			&selected,
+			&[(BenchmarkParameter::b, 1)],
+		));
 	});
 
 	// Check postcondition for benchmark `bad_verify` is invalid.
 	let selected = SelectedBenchmark::bad_verify;
 
-	let closure =
-		<SelectedBenchmark as BenchmarkingSetup<Test>>::instance(&selected, &[(BenchmarkParameter::x, 10000)], true)
-			.expect("failed to create closure");
-
 	new_test_ext().execute_with(|| {
-		assert_err!(closure(), "You forgot to sort!");
+		assert_err!(
+			<SelectedBenchmark as BenchmarkingSetup<Test>>::unit_test_instance(
+				&selected,
+				&[(BenchmarkParameter::x, 10000)],
+			),
+			"You forgot to sort!"
+		);
 	});
 }
 

--- a/tokens/src/impls.rs
+++ b/tokens/src/impls.rs
@@ -120,13 +120,14 @@ where
 		asset: Self::AssetId,
 		dest: &AccountId,
 		amount: Self::Balance,
+		preservation: Preservation,
 		precision: Precision,
 		fortitude: Fortitude,
 	) -> Result<Self::Balance, DispatchError> {
 		if TestKey::contains(&asset) {
-			A::burn_from(dest, amount, precision, fortitude)
+			A::burn_from(dest, amount, preservation, precision, fortitude)
 		} else {
-			B::burn_from(asset, dest, amount, precision, fortitude)
+			B::burn_from(asset, dest, amount, preservation, precision, fortitude)
 		}
 	}
 
@@ -295,6 +296,7 @@ where
 	fn burn_from(
 		dest: &AccountId,
 		amount: Self::Balance,
+		preservation: Preservation,
 		precision: Precision,
 		fortitude: Fortitude,
 	) -> Result<Self::Balance, DispatchError> {
@@ -302,6 +304,7 @@ where
 			GetCurrencyId::get(),
 			dest,
 			C::convert_balance_back(amount, GetCurrencyId::get())?,
+			preservation,
 			precision,
 			fortitude,
 		)

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1858,6 +1858,8 @@ impl<T: Config> fungibles::Mutate<T::AccountId> for Pallet<T> {
 		asset_id: Self::AssetId,
 		who: &T::AccountId,
 		amount: Self::Balance,
+		// TODO: Respect preservation
+		_preservation: Preservation,
 		// TODO: Respect precision
 		_precision: Precision,
 		// TODO: Respect fortitude
@@ -2492,10 +2494,18 @@ where
 	fn burn_from(
 		who: &T::AccountId,
 		amount: Self::Balance,
+		preservation: Preservation,
 		precision: Precision,
 		fortitude: Fortitude,
 	) -> Result<Self::Balance, DispatchError> {
-		<Pallet<T> as fungibles::Mutate<_>>::burn_from(GetCurrencyId::get(), who, amount, precision, fortitude)
+		<Pallet<T> as fungibles::Mutate<_>>::burn_from(
+			GetCurrencyId::get(),
+			who,
+			amount,
+			preservation,
+			precision,
+			fortitude,
+		)
 	}
 
 	fn transfer(

--- a/tokens/src/tests_events.rs
+++ b/tokens/src/tests_events.rs
@@ -174,6 +174,7 @@ fn pallet_fungibles_mutate_deposit_events() {
 				DOT,
 				&ALICE,
 				500,
+				Preservation::Expendable,
 				Precision::Exact,
 				Fortitude::Polite
 			));

--- a/tokens/src/tests_fungibles.rs
+++ b/tokens/src/tests_fungibles.rs
@@ -51,7 +51,14 @@ fn fungibles_mutate_trait_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(<Tokens as fungibles::Mutate<_>>::mint_into(DOT, &ALICE, 10));
 		assert_eq!(
-			<Tokens as fungibles::Mutate<_>>::burn_from(DOT, &ALICE, 8, Precision::Exact, Fortitude::Polite),
+			<Tokens as fungibles::Mutate<_>>::burn_from(
+				DOT,
+				&ALICE,
+				8,
+				Preservation::Expendable,
+				Precision::Exact,
+				Fortitude::Polite
+			),
 			Ok(8)
 		);
 	});
@@ -718,6 +725,7 @@ fn fungibles_mutate_convert_should_work() {
 				DOT,
 				&BOB,
 				10000,
+				Preservation::Expendable,
 				Precision::Exact,
 				Fortitude::Polite
 			));

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -147,6 +147,7 @@ impl Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = ();
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -145,6 +145,7 @@ impl Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = ();
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/xtokens/src/mock/para_teleport.rs
+++ b/xtokens/src/mock/para_teleport.rs
@@ -143,6 +143,7 @@ impl Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = ();
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/xtokens/src/mock/relay.rs
+++ b/xtokens/src/mock/relay.rs
@@ -123,6 +123,7 @@ impl Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = ();
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, KusamaNetwork>;


### PR DESCRIPTION
## Noteworthy changes 
* Update benchmarking macro. I essentially integrated the changes from: https://github.com/paritytech/polkadot-sdk/pull/3934/.
* Add `Preservation` arg to burn function in fungible trait
* Add `XcmRecorder` to `XcmConfig` for mocks

I would be very happy if this is released soon on crates.io ;)