### PR TITLE
polkadot v1.13.0

### DIFF
--- a/Cargo.dev.toml
+++ b/Cargo.dev.toml
@@ -37,35 +37,35 @@ scale-info = { version = "2.10.0", default-features = false, features = ["derive
 serde = { version = "1.0.189" }
 parity-scale-codec = { version = "3.6.5", default-features = false, features = ["max-encoded-len"] }
 
-cumulus-pallet-xcm = { version = "0.13.0", default-features = false }
-cumulus-primitives-core = { version = "0.13.0", default-features = false }
-frame-benchmarking = { version = "34.0.0", default-features = false }
-frame-support = { version = "34.0.0", default-features = false }
-frame-system = { version = "34.0.1", default-features = false }
-pallet-balances = { version = "35.0.0", default-features = false }
-pallet-elections-phragmen = { version = "35.0.0", default-features = false }
-pallet-message-queue = { version = "37.0.0", default-features = false }
-pallet-preimage = { version = "34.0.0", default-features = false }
-pallet-root-testing = { version = "10.0.0", default-features = false }
-pallet-scheduler = { version = "35.0.0", default-features = false }
-pallet-timestamp = { version = "33.0.0", default-features = false }
-pallet-treasury = { version = "33.0.0", default-features = false }
-pallet-xcm = { version = "13.0.0", default-features = false }
-polkadot-parachain-primitives = { version = "12.0.0", default-features = false }
-polkadot-runtime-common = { version = "13.0.0", default-features = false }
-polkadot-runtime-parachains = { version = "13.0.0", default-features = false }
-sp-api = { version = "32.0.0", default-features = false }
-sp-application-crypto = { version = "36.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.14.0", default-features = false }
+cumulus-primitives-core = { version = "0.14.0", default-features = false }
+frame-benchmarking = { version = "35.0.0", default-features = false }
+frame-support = { version = "35.0.0", default-features = false }
+frame-system = { version = "35.0.0", default-features = false }
+pallet-balances = { version = "36.0.0", default-features = false }
+pallet-elections-phragmen = { version = "36.0.0", default-features = false }
+pallet-message-queue = { version = "38.0.0", default-features = false }
+pallet-preimage = { version = "35.0.0", default-features = false }
+pallet-root-testing = { version = "11.0.0", default-features = false }
+pallet-scheduler = { version = "36.0.0", default-features = false }
+pallet-timestamp = { version = "34.0.0", default-features = false }
+pallet-treasury = { version = "34.0.0", default-features = false }
+pallet-xcm = { version = "14.0.0", default-features = false }
+polkadot-parachain-primitives = { version = "13.0.0", default-features = false }
+polkadot-runtime-common = { version = "14.0.0", default-features = false }
+polkadot-runtime-parachains = { version = "14.0.0", default-features = false }
+sp-api = { version = "33.0.0", default-features = false }
+sp-application-crypto = { version = "37.0.0", default-features = false }
 sp-arithmetic = { version = "26.0.0", default-features = false }
-sp-core = { version = "33.0.1", default-features = false }
-sp-io = { version = "36.0.0", default-features = false }
-sp-runtime = { version = "37.0.0", default-features = false }
-sp-runtime-interface = { version = "27.0.0", default-features = false }
-sp-staking = { version = "32.0.0", default-features = false }
+sp-core = { version = "34.0.0", default-features = false }
+sp-io = { version = "37.0.0", default-features = false }
+sp-runtime = { version = "38.0.0", default-features = false }
+sp-runtime-interface = { version = "28.0.0", default-features = false }
+sp-staking = { version = "33.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 sp-storage = { version = "21.0.0", default-features = false }
-xcm = { version = "13.0.1", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "13.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "13.0.0", package = "staging-xcm-executor", default-features = false }
+xcm = { version = "14.0.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "14.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "14.0.0", package = "staging-xcm-executor", default-features = false }
 
-xcm-simulator = { version = "13.0.0" }
+xcm-simulator = { version = "14.0.0" }

--- a/asset-registry/src/tests.rs
+++ b/asset-registry/src/tests.rs
@@ -20,8 +20,11 @@ use sp_runtime::{
 use xcm::{v3, v4::prelude::*, VersionedLocation};
 use xcm_simulator::TestExt;
 
+#[allow(deprecated)]
 type OldLocation = xcm::v2::MultiLocation;
+#[allow(deprecated)]
 type OldJunctions = xcm::v2::Junctions;
+#[allow(deprecated)]
 type OldJunction = xcm::v2::Junction;
 
 fn treasury_account() -> AccountId32 {
@@ -585,12 +588,14 @@ fn test_asset_authority() {
 #[test]
 fn test_v2_to_v3_incompatible_multilocation() {
 	// Assert that V2 and V3 Location both are encoded differently
+
+	#[allow(deprecated)]
+	let old_location = OldLocation::new(
+		0,
+		OldJunctions::X1(OldJunction::GeneralKey(vec![0].try_into().unwrap())),
+	);
 	assert!(
-		OldLocation::new(
-			0,
-			OldJunctions::X1(OldJunction::GeneralKey(vec![0].try_into().unwrap()))
-		)
-		.encode() != Location::new(0, [Junction::from(BoundedVec::try_from(vec![0]).unwrap())]).encode()
+		old_location.encode() != Location::new(0, [Junction::from(BoundedVec::try_from(vec![0]).unwrap())]).encode()
 	);
 }
 


### PR DESCRIPTION
No noteworthy changes, just allowed some freshly deprecated xcm types in tests.

Again, I would be happy if this is released soon after the merge. :)